### PR TITLE
[BUGFIX] Fix incompatibility issue with FluidTYPO3/flux extension #60

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -268,8 +268,10 @@ class PageLayoutHeader
     {
         $allowedDoktypes = [1];     // By default only add normal pages
 
+        /** @var CMS\Extbase\Object\ObjectManager $objectManager */
+        $objectManager = CMS\Core\Utility\GeneralUtility::makeInstance(CMS\Extbase\Object\ObjectManager::class);
         /** @var CMS\Extbase\Configuration\ConfigurationManager $configurationManager */
-        $configurationManager =  CMS\Core\Utility\GeneralUtility::makeInstance(CMS\Extbase\Configuration\ConfigurationManager::class);
+        $configurationManager = $objectManager->get(CMS\Extbase\Configuration\ConfigurationManager::class);
         $configuration = $configurationManager->getConfiguration(CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS, 'yoastseo');
 
         foreach ($configuration['allowedDoktypes'] as $key => $doktype) {


### PR DESCRIPTION
When FluidTYPO3/flux is installed Yoast/Yoast-SEO-for-TYPO3 causes PHP error on page module. No idea why...

Fixes: #60 