### PR TITLE
[BUGFIX] Disable snippet preview does not work in localized pages

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -110,7 +110,7 @@ class PageLayoutHeader
             }
         }
 
-        if (!YoastUtility::snippetPreviewEnabled($currentPage['uid'])) {
+        if (!YoastUtility::snippetPreviewEnabled((int)$pageLayoutController->current_sys_language == 0 ? $currentPage['uid'] : $currentPage['pid'])) {
             return '';
         }
 


### PR DESCRIPTION
YoastUtility::snippetPreviewEnabled was called with the uid of the page_language_overlay record, instead of uid of page. 

So the wrong typoscript config was used in Backend Module.