### PR TITLE
[TASK] Don't use default rendering of title tag from TYPO3

### DIFF
--- a/Classes/Frontend/PageRenderer/PageMetaRenderer.php
+++ b/Classes/Frontend/PageRenderer/PageMetaRenderer.php
@@ -39,6 +39,7 @@ class PageMetaRenderer implements SingletonInterface
         $config = $typoScriptService->convertTypoScriptArrayToPlainArray($configManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_FULL_TYPOSCRIPT));
 
         if (is_array($config)
+            && !(bool)$GLOBALS['TSFE']->page['tx_yoastseo_dont_use']
             && (int) ObjectAccess::getPropertyPath($config, 'config.yoast_seo.enabled') !== 0
             && ObjectAccess::getPropertyPath($config, 'plugin.tx_yoastseo.settings') !== null
             && ObjectAccess::getPropertyPath($config, 'plugin.tx_yoastseo.view') !== null

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -2,6 +2,12 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'pages',
     array(
+        'tx_yoastseo_dont_use' => array(
+            'label' => 'Hide Yoast SEO in frontend',
+            'config' => array(
+                'type' => 'check'
+            )
+        ),
         'tx_yoastseo_focuskeyword' => array(
             'label' => 'SEO focus keyword',
             'config' => array(
@@ -152,6 +158,7 @@
     --linebreak--, tx_yoastseo_facebook_image, 
     --linebreak--, tx_yoastseo_twitter_title, 
     --linebreak--, tx_yoastseo_twitter_description, 
-    --linebreak--, tx_yoastseo_twitter_image
+    --linebreak--, tx_yoastseo_twitter_image,
+    --linebreak--, tx_yoastseo_dont_use
     '
 );

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -2,6 +2,12 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'pages_language_overlay',
     array(
+        'tx_yoastseo_dont_use' => array(
+            'label' => 'Hide Yoast SEO in frontend',
+            'config' => array(
+                'type' => 'check'
+            )
+        ),
         'tx_yoastseo_title' => array(
             'label' => 'SEO title',
             'config' => array(
@@ -152,6 +158,7 @@
      --linebreak--, tx_yoastseo_facebook_image,
      --linebreak--, tx_yoastseo_twitter_title, 
      --linebreak--, tx_yoastseo_twitter_description, 
-     --linebreak--, tx_yoastseo_twitter_image
+     --linebreak--, tx_yoastseo_twitter_image,
+     --linebreak--, tx_yoastseo_dont_use
     '
 );

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,5 +1,8 @@
 config.yoast_seo.enabled = 1
-
+config.noPageTitle = 2
+[page|tx_yoastseo_dont_use = 1]
+    config.noPageTitle = 0
+[global]
 plugin.tx_yoastseo {
     settings {
         og.image.width = 640c

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE pages (
 	tx_yoastseo_twitter_title varchar(255) DEFAULT '' NOT NULL,
 	tx_yoastseo_twitter_description varchar(255) DEFAULT '' NOT NULL,
 	tx_yoastseo_twitter_image int(11) DEFAULT '0' NOT NULL,
+	tx_yoastseo_dont_use tinyint(3) DEFAULT '0' NOT NULL,
 );
 
 #
@@ -28,4 +29,5 @@ CREATE TABLE pages_language_overlay (
 	tx_yoastseo_twitter_title varchar(255) DEFAULT '' NOT NULL,
 	tx_yoastseo_twitter_description varchar(255) DEFAULT '' NOT NULL,
 	tx_yoastseo_twitter_image int(11) DEFAULT '0' NOT NULL,
+	tx_yoastseo_dont_use tinyint(3) DEFAULT '0' NOT NULL,
 );


### PR DESCRIPTION
Don't use default rendering of title tag from TYPO3 when the Yoast plugin is enabled. Also added possibility to disable Yoast in frontend on a specific page