### PR TITLE
[BUGFIX] add missing tx_yoastseo_title from pageOverlayFields

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -84,7 +84,8 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array(
 );
 
 // allow social meta fields to be overlaid
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_yoastseo_facebook_title'
+$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_yoastseo_title'
+    . ',tx_yoastseo_facebook_title'
     . ',tx_yoastseo_facebook_description'
     . ',tx_yoastseo_twitter_title'
     . ',tx_yoastseo_twitter_description';


### PR DESCRIPTION
Adds the missing entry for `tx_yoastseo_title` in `pageOverlayFields`

fixes #122