### PR TITLE
[BUGFIX] Adds the missing entries for 'tx_yoastseo_robot_instructions…

### DIFF
--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -2,12 +2,6 @@
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
     'pages_language_overlay',
     array(
-        'tx_yoastseo_dont_use' => array(
-            'label' => 'Hide Yoast SEO in frontend',
-            'config' => array(
-                'type' => 'check'
-            )
-        ),
         'tx_yoastseo_title' => array(
             'label' => 'SEO title',
             'config' => array(
@@ -158,7 +152,6 @@
      --linebreak--, tx_yoastseo_facebook_image,
      --linebreak--, tx_yoastseo_twitter_title, 
      --linebreak--, tx_yoastseo_twitter_description, 
-     --linebreak--, tx_yoastseo_twitter_image,
-     --linebreak--, tx_yoastseo_dont_use
+     --linebreak--, tx_yoastseo_twitter_image
     '
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -84,8 +84,12 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array(
 );
 
 // allow social meta fields to be overlaid
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_yoastseo_title'
+$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=
+      ',tx_yoastseo_canonical_url'
+    . ',tx_yoastseo_dont_use'
     . ',tx_yoastseo_facebook_title'
     . ',tx_yoastseo_facebook_description'
+    . ',tx_yoastseo_robot_instructions'
+    . ',tx_yoastseo_title'
     . ',tx_yoastseo_twitter_title'
     . ',tx_yoastseo_twitter_description';

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -86,7 +86,6 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array(
 // allow social meta fields to be overlaid
 $GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=
       ',tx_yoastseo_canonical_url'
-    . ',tx_yoastseo_dont_use'
     . ',tx_yoastseo_facebook_title'
     . ',tx_yoastseo_facebook_description'
     . ',tx_yoastseo_robot_instructions'

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -28,6 +28,5 @@ CREATE TABLE pages_language_overlay (
 	tx_yoastseo_facebook_image int(11) DEFAULT '0' NOT NULL,
 	tx_yoastseo_twitter_title varchar(255) DEFAULT '' NOT NULL,
 	tx_yoastseo_twitter_description varchar(255) DEFAULT '' NOT NULL,
-	tx_yoastseo_twitter_image int(11) DEFAULT '0' NOT NULL,
-	tx_yoastseo_dont_use tinyint(3) DEFAULT '0' NOT NULL,
+	tx_yoastseo_twitter_image int(11) DEFAULT '0' NOT NULL
 );


### PR DESCRIPTION
Adds the missing entries for `tx_yoastseo_canonical_url`, `tx_yoastseo_robot_instructions` to `$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields']` also ordered the list alfabetically. 

This fixes:
- The filled fields in the backend (in the language overlay) don't show up on the frontend
- The filled fields in the original language override the values on the translated page in the frontend (language mix in the meta tags)

Removed `tx_yoastseo_dont_use` from `pages_language_overlay` because of the typoscript condition in Configuration/TypoScript/setup.txt
```
[page|tx_yoastseo_dont_use = 1]
    config.noPageTitle = 0
[global]
```
The `config.noPageTitle` option works for the page and all it's translations. With typoscript conditions you cannot check for the language. ([globalVar = GP:L = 0] isn't working)