### PR TITLE
[BUGFIX] Fix syntax for twitter card metatags

### DIFF
--- a/Resources/Private/Partials/TwitterCards.html
+++ b/Resources/Private/Partials/TwitterCards.html
@@ -1,16 +1,19 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:yoast="http://typo3.org/ns/YoastSeoForTypo3/YoastSeo/ViewHelpers" data-namespace-typo3-fluid="true">
     <f:if condition="{data.tx_yoastseo_twitter_title}">
         <f:then>
-            <meta property="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{data.tx_yoastseo_twitter_title}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}')}">
+          <meta name="twitter:card" content="summary">
+          <meta name="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{data.tx_yoastseo_twitter_title}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}')}">
         </f:then>
         <f:else>
             <f:if condition="{data.title}">
                 <f:if condition="{yoast:keyValue(obj: data, prop: '{settings.titleFieldName}')}">
                     <f:then>
-                        <meta property="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{yoast:keyValue(obj: data, prop: '{settings.titleFieldName}')}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}', else: '')}">
+                        <meta name="twitter:card" content="summary">
+                        <meta name="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{yoast:keyValue(obj: data, prop: '{settings.titleFieldName}')}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}', else: '')}">
                     </f:then>
                     <f:else>
-                        <meta property="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{data.title}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}', else: '')}">
+                        <meta name="twitter:card" content="summary">
+                        <meta name="twitter:title" content="{f:if(condition: '{settings.titlePrepend}', then: '{settings.titlePrepend} ', else: '')}{data.title}{f:if(condition: '{settings.titleAppend}', then: ' {settings.titleAppend}', else: '')}">
                     </f:else>
                 </f:if>
             </f:if>
@@ -18,11 +21,11 @@
     </f:if>
     <f:if condition="{data.tx_yoastseo_twitter_description}">
         <f:then>
-            <meta property="twitter:description" content="{data.tx_yoastseo_twitter_description}">
+            <meta name="twitter:description" content="{data.tx_yoastseo_twitter_description}">
         </f:then>
         <f:else>
             <f:if condition="{yoast:keyValue(obj: data, prop: '{settings.descriptionFieldName}')}">
-                <meta property="twitter:description" content="{yoast:keyValue(obj: data, prop: '{settings.descriptionFieldName}')}">
+                <meta name="twitter:description" content="{yoast:keyValue(obj: data, prop: '{settings.descriptionFieldName}')}">
             </f:if>
         </f:else>
     </f:if>
@@ -31,12 +34,12 @@
         <f:then>
             <f:for each="{twitterCardsImages}" as="twitterCardsImage" iteration="iteration">
                 <f:if condition="{iteration.cycle} <= 1">
-                    <meta property="twitter:image" content="{f:uri.image(image: twitterCardsImage, width: settings.twitter.image.width, height: settings.twitter.image.height, absolute: 1)}">
+                    <meta name="twitter:image" content="{f:uri.image(image: twitterCardsImage, width: settings.twitter.image.width, height: settings.twitter.image.height, absolute: 1)}">
                 </f:if>
             </f:for>
         </f:then>
         <f:else>
-            <meta property="twitter:image" content="{f:uri.image(src: '{yoast:socialMediaImage(uid: \'0\', field: \'tx_yoastseo_settings_twitter_image\', table: \'tx_yoastseo_settings\')}', treatIdAsReference: 1, width: settings.twitter.image.width, height: settings.twitter.image.height, absolute: 1)}">
+            <meta name="twitter:image" content="{f:uri.image(src: '{yoast:socialMediaImage(uid: \'0\', field: \'tx_yoastseo_settings_twitter_image\', table: \'tx_yoastseo_settings\')}', treatIdAsReference: 1, width: settings.twitter.image.width, height: settings.twitter.image.height, absolute: 1)}">
         </f:else>
     </f:if>
 </html>


### PR DESCRIPTION
Twitter cards must use the 'name' attribute in the metatag instead of the 'property' attribute. Otherwise they can not be parsed by twitter, see https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started