### PR TITLE
Change filepath to preview snippet css file

### DIFF
--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -131,8 +131,7 @@ class SnippetPreview extends AbstractNode
     {
         $allowedDoktypes = YoastUtility::getAllowedDoktypes();
         $resultArray = $this->initializeResultArray();
-        $publicResourcesPath = PathUtility::getAbsoluteWebPath('../typo3conf/ext/yoast_seo/Resources/Public/');
-        $resultArray['stylesheetFiles'][] = $publicResourcesPath . 'CSS/yoast-seo-tca.min.css';
+        $resultArray['stylesheetFiles'][] = 'EXT:yoast_seo/Resources/Public/CSS/yoast-seo-tca.min.css';
 
         if ($this->data['tableName'] != 'pages' || in_array((int)$this->data['databaseRow']['doktype'][0], $allowedDoktypes)) {
             $firstFocusKeyword = YoastUtility::getFocusKeywordOfPage((int)$this->data['databaseRow']['uid'], $this->data['tableName']);


### PR DESCRIPTION
The current implementation breaks the preview snippet when TYPO3 in installed in a subdirectory.
The CSS file get generated without any content.

This PR is currently only tested in TYPO3 8.7.10 with composer mode.

resolves #152 