### PR TITLE
Removed pathOverride and only use slug, fixed documentation identifiers

### DIFF
--- a/Configuration/TypoScript/Setup/Lib.typoscript
+++ b/Configuration/TypoScript/Setup/Lib.typoscript
@@ -114,11 +114,6 @@ lib.yoastSEO {
         htmlSpecialChars = 1
     }
 
-    pathOverride = TEXT
-    pathOverride {
-        field = tx_realurl_pathsegment
-    }
-
     og {
         siteName = TEXT
         siteName.value < sitetitle

--- a/Configuration/TypoScript/Setup/Preview.typoscript
+++ b/Configuration/TypoScript/Setup/Preview.typoscript
@@ -54,9 +54,6 @@ yoast_seo_preview {
         60 =< lib.yoastSEO.slug
         60.wrap = <slug>|</slug>
 
-        70 =< lib.yoastSEO.pathOverride
-        70.wrap = <pathOverride>|</pathOverride>
-
         wrap = <meta>|</meta>
     }
 

--- a/Documentation/OtherPlugins/Analysis/Index.rst
+++ b/Documentation/OtherPlugins/Analysis/Index.rst
@@ -6,7 +6,7 @@
 .. include:: ../../Includes.txt
 
 
-.. _otherplugins:
+.. _otherplugins-analysis:
 
 Analysis
 ========

--- a/Documentation/OtherPlugins/Index.rst
+++ b/Documentation/OtherPlugins/Index.rst
@@ -6,7 +6,7 @@
 .. include:: ../Includes.txt
 
 
-.. _otherplugins:
+.. _otherplugins-index:
 
 Integration in other plugins
 ============================

--- a/Documentation/OtherPlugins/Sitemap/Index.rst
+++ b/Documentation/OtherPlugins/Sitemap/Index.rst
@@ -6,7 +6,7 @@
 .. include:: ../../Includes.txt
 
 
-.. _otherplugins:
+.. _otherplugins-sitemap:
 
 Add extra sitemaps
 ==================

--- a/Resources/Public/JavaScript/Tca.js
+++ b/Resources/Public/JavaScript/Tca.js
@@ -31,16 +31,18 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                 pageContent += element.textContent;
             });
 
+            var slug = $metaSection.find('slug').text().replace(/^\/|\/$/g, '');
+
             var snippetPreview = new YoastSEO.SnippetPreview({
                 data: {
                     title: $metaSection.find('title').text(),
                     metaDesc: $metaSection.find('description').text(),
-                    urlPath: $metaSection.find('pathOverride').text()
+                    urlPath: slug
                 },
                 baseURL: $metaSection.find('url').text().replace($metaSection.find('slug').text(), '/'),
                 placeholder: {
                     title: $metaSection.find('pageTitle').text(),
-                    urlPath: $metaSection.find('slug').text().replace(/^\/|\/$/g, '')
+                    urlPath: slug
                 },
                 targetElement: $snippetPreviewElement.get(0),
                 previewMode: 'desktop'

--- a/Resources/Public/JavaScript/app.js
+++ b/Resources/Public/JavaScript/app.js
@@ -64,15 +64,17 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
 
             var $focusKeywordElement = $('#' + tx_yoast_seo.settings.targetElementId + '_focusKeyword');
 
+            var slug = $metaSection.find('slug').text().replace(/^\/|\/$/g, '');
+
             var snippetPreview = new YoastSEO.SnippetPreview({
                 data: {
                     title: $metaSection.find('title').text(),
                     metaDesc: $metaSection.find('description').text(),
-                    urlPath: $metaSection.find('pathOverride').text(),
+                    urlPath: slug
                 },
                 baseURL: $metaSection.find('url').text().replace($metaSection.find('slug').text(), '/'),
                 placeholder: {
-                    urlPath: $metaSection.find('slug').text().replace(/^\/|\/$/g, '')
+                    urlPath: slug
                 },
                 targetElement: $snippetPreview.get(0),
                 callbacks: {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove the use of pathOverride and only use slug
* Fixed Documentation identifiers

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* With a TCA record, that has additional parameters AND the (detail-)page which is used has a path segment, the additional parameters were not shown in the link in the backend.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
