### PR TITLE
Bugfix/220 routeenhancers check

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -257,7 +257,7 @@ class PageLayoutHeader
                 $returnHtml .= '
                 <div class="t3-grid-cell yoast yoastSeo yoastSeo--small">
                     <div class="callout callout-warning callout-body">
-                        It seems that you have configured routeEnhancers for this site with type pageType. When you do this, it is necessary that you also add the yoast pageType.<br />
+                        It seems that you have configured routeEnhancers for this site with type pageType. When you do this, it is necessary that you also add the pageType for the Yoast Snippetpreview.<br />
                         Please add a mapping for type ' . self::FE_PREVIEW_TYPE . ' and map it for example to \'yoast-snippetpreview.json\'.<br />
                         <strong><a href="https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.5/Feature-86160-PageTypeEnhancerForMappingTypeParameter.html" target="_blank">You can find an example configuration here.</a></strong>
                     </div>

--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -44,6 +44,13 @@ class PageLayoutHeader
     protected $pageRenderer;
 
     /**
+     * Route enhancer error
+     *
+     * @var bool
+     */
+    protected $routeEnhancerError = false;
+
+    /**
      * Initialize the page renderer
      */
     public function __construct()
@@ -212,7 +219,7 @@ class PageLayoutHeader
             ];
             $url = $uriBuilder->buildUriFromRoute('record_edit', $urlParameters);
 
-            return '
+            $returnHtml = '
                 <div class="yoast-snippet-header">
                     <div class="yoast-snippet-header-icons btn-group btn-group-sm">
                         <a href="#" class="yoast-collapse" data-collapse-target="' . $targetElementId . '">
@@ -233,7 +240,10 @@ class PageLayoutHeader
                         </a>
                     </div>
                     <div class="yoast-snippet-header-label">Yoast SEO</div>
-                </div>
+                </div>';
+
+            if ($this->routeEnhancerError === false) {
+                $returnHtml .= '
                 <input id="focusKeyword" style="display: none" />
                 <div id="' . $targetElementId . '" class="t3-grid-cell yoastSeo yoastSeo--small">
                     <!-- ' . $targetElementId . ' -->
@@ -243,9 +253,19 @@ class PageLayoutHeader
                       <div class="bounce3"></div>
                     </div>
                 </div>';
-        } else {
-            return '';
+            } else {
+                $returnHtml .= '
+                <div class="t3-grid-cell yoast yoastSeo yoastSeo--small">
+                    <div class="callout callout-warning callout-body">
+                        It seems that you have configured routeEnhancers for this site with type pageType. When you do this, it is necessary that you also add the yoast pageType.<br />
+                        Please add a mapping for type ' . self::FE_PREVIEW_TYPE . ' and map it for example to \'yoast-snippetpreview.json\'.<br />
+                        <strong><a href="https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.5/Feature-86160-PageTypeEnhancerForMappingTypeParameter.html" target="_blank">You can find an example configuration here.</a></strong>
+                    </div>
+                </div>';
+            }
+            return $returnHtml;
         }
+        return '';
     }
 
     /**
@@ -321,6 +341,8 @@ class PageLayoutHeader
                 $additionalGetVars .= '&MP=' . $mountPointInformation['MPvar'];
             }
             if ($site instanceof CMS\Core\Site\Entity\Site) {
+                $this->checkRouteEnhancers($site);
+
                 $additionalQueryParams = [];
                 parse_str($additionalGetVars, $additionalQueryParams);
                 $additionalQueryParams['_language'] = $site->getLanguageById($languageId);
@@ -335,6 +357,31 @@ class PageLayoutHeader
             return $uri;
         }
         return '#';
+    }
+
+    /**
+     * Check the route enhancers
+     *
+     * @param \TYPO3\CMS\Core\Site\Entity\Site $site
+     */
+    protected function checkRouteEnhancers(CMS\Core\Site\Entity\Site $site)
+    {
+        if (isset($site->getConfiguration()['routeEnhancers'])) {
+            $typeEnhancer = $yoastTypeEnhancer = false;
+            foreach ($site->getConfiguration()['routeEnhancers'] as $routeEnhancer) {
+                if ($routeEnhancer['type'] === 'PageType') {
+                    $typeEnhancer = true;
+                    foreach ($routeEnhancer['map'] as $pageType) {
+                        if ($pageType === self::FE_PREVIEW_TYPE) {
+                            $yoastTypeEnhancer = true;
+                        }
+                    }
+                }
+            }
+            if ($typeEnhancer === true && $yoastTypeEnhancer === false) {
+                $this->routeEnhancerError = true;
+            }
+        }
     }
 
     /**

--- a/Resources/Public/JavaScript/app.js
+++ b/Resources/Public/JavaScript/app.js
@@ -30,6 +30,11 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
         }
     };
 
+    var showJsError = function(targetElement, text) {
+        targetElement.find('.spinner').hide();
+        targetElement.html('<div class="callout callout-warning">' + text + '</div>');
+    };
+
     // make sure the document is ready before we interact with the DOM
     // use the jQuery (ready) callback
     $(function () {
@@ -40,6 +45,10 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
         }
 
         previewRequest.done(function (previewDocument) {
+            if (!previewDocument.id) {
+                showJsError($targetElement, 'We got an error when requesting <a href="' + tx_yoast_seo.settings.preview + '">' + tx_yoast_seo.settings.preview + '</a>. The JSON returned is not valid, please check the URL.');
+                return;
+            }
             // wait with UI markup until the preview is loaded
             var $snippetPreview = $targetElement.append('<div class="snippetPreview yoastPanel" />').find('.snippetPreview');
             $targetElement.find('.spinner').hide();
@@ -212,10 +221,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
         $('div#snippet_title.snippet_container.snippet-editor__container').off('click');
 
         previewRequest.fail(function (jqXHR) {
-            var text = 'We got an error ' + jqXHR.status + ' (' + jqXHR.statusText + ') when requesting <a href="' + tx_yoast_seo.settings.preview + '" target="_blank">' + tx_yoast_seo.settings.preview + '</a> to analyse your content. Please check your javascript console for more information.';
-
-            $targetElement.find('.spinner').hide();
-            $targetElement.html('<div class="callout callout-warning">' + text + '</div>');
+            showJsError($targetElement, 'We got an error ' + jqXHR.status + ' (' + jqXHR.statusText + ') when requesting <a href="' + tx_yoast_seo.settings.preview + '" target="_blank">' + tx_yoast_seo.settings.preview + '</a> to analyse your content. Please check your javascript console for more information.');
         });
     });
 });

--- a/Resources/Public/JavaScript/app.js
+++ b/Resources/Public/JavaScript/app.js
@@ -35,6 +35,10 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
     $(function () {
         var $targetElement = $('#' + tx_yoast_seo.settings.targetElementId);
 
+        if ($targetElement.length === 0) {
+            return;
+        }
+
         previewRequest.done(function (previewDocument) {
             // wait with UI markup until the preview is loaded
             var $snippetPreview = $targetElement.append('<div class="snippetPreview yoastPanel" />').find('.snippetPreview');


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Checks if there's invalid routeEnhancers config (in the situation where there's site configuration) and checks if there's a valid JSON returned

## Relevant technical choices:

* The routeEnhancers config check is done server side, valid JSON client-side. The errors are in English only. Not too happy with the JS code but that needs a refactoring anyway.

## Test instructions

This PR can be tested by following these steps:

* Add a routeEnhancer config for PageType (for example sitemap) but not for yoast pagetype

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #220 
