### PR TITLE
Prevent overwrite settings from other RealURL autoconfig hooks

### DIFF
--- a/Classes/Hooks/RealUrlAutoConfiguration.php
+++ b/Classes/Hooks/RealUrlAutoConfiguration.php
@@ -24,7 +24,7 @@ class RealUrlAutoConfiguration
 {
     public function addSitemapConfiguration($params)
     {
-        return array_merge(
+        return array_merge_recursive(
             $params['config'],
             [
                 'fileName' => [


### PR DESCRIPTION
## Summary

* array_merge will be remove all other "fileName"-settings from realurl_autoconfig. This could be unwanted.

## Test instructions

After install EXT:yoast_seo 3.0.4 look at the generated RealURL configuration. All settings like "TYPO3_CONF_VARS.EXTCONF.realurl.DOMAIN.fileName.acceptHTMLsuffix" will be gone.

*

## Quality assurance

* [x] I have tested this code to the best of my abilities
