### PR TITLE
[FEATURE] Handle commaseparated list for rootPid

### DIFF
--- a/Classes/UserFunc/SitemapXml.php
+++ b/Classes/UserFunc/SitemapXml.php
@@ -117,7 +117,7 @@ class SitemapXml
             array_key_exists('table', $sitemapSettings)
         ) {
             if ($sitemapSettings['table'] === 'pages') {
-                $rootPids = $sitemapSettings['rootPid'] ? explode(',', $sitemapSettings['rootPid']) : [$tsfe->id];
+                $rootPids = $sitemapSettings['rootPid'] ? GeneralUtility::intExplode(',', $sitemapSettings['rootPid'], true) : [$tsfe->id];
                 $where = $sitemapSettings['additionalWhere'] ?: '';
 
                 foreach ($rootPids as $rootPid) {
@@ -129,7 +129,7 @@ class SitemapXml
                 }
             } else {
                 $where[] = $sitemapSettings['additionalWhere'] ?: '1=1';
-                $rootPids = $sitemapSettings['rootPid'] ? explode(',', $sitemapSettings['rootPid']) : [];
+                $rootPids = $sitemapSettings['rootPid'] ? GeneralUtility::intExplode(',', $sitemapSettings['rootPid'], true) : [];
                 if (!empty($rootPids)) {
                     $where[] = ' AND pid IN (' . implode(',', $rootPids) . ')';
                 }


### PR DESCRIPTION
## Summary

There is now the possibility to specify several rootPids for pages. In addition, the rootPid is now also available for other plugins.

In the future, this could be followed by a recursive option. This as a first step.


## Test instructions

Just config an other plugin sitemap for two or more rootPids


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #230 
