### PR TITLE
[BUGFIX] Pages ignore additionalWhere settings

### DIFF
--- a/Classes/UserFunc/SitemapXml.php
+++ b/Classes/UserFunc/SitemapXml.php
@@ -119,7 +119,11 @@ class SitemapXml
                 $rootPid = $sitemapSettings['rootPid'] ?: $tsfe->id;
                 $where = $sitemapSettings['additionalWhere'] ?: '';
 
-                $docs[] = $tsfe->sys_page->getPage($rootPid);
+                $rootPage = reset($this->getTSFE()->sys_page->getMenuForPages([$rootPid], '*', 'sorting', $where));
+                if ($rootPage) {
+                    $docs[] = $rootPage;
+                }
+
                 $docs = array_filter(
                     $this->getSubPages($rootPid, $docs, $where),
                     '\YoastSeoForTypo3\YoastSeo\UserFunc\SitemapXml::filterNoIndexPages'


### PR DESCRIPTION
## Summary

Now the SitemapUtility uses the core functionality getMenuForPages to append a addtionalWhereSetting. If this functionality finds more than one entry it returns only one.

If this function founds nothing there is a false and the page will not be added.

## Test instructions

This PR can be tested by following these steps:

* Set a rootPid e.g. 1
* additionalWhere = AND uid > 1 to exlude the rootPage

Of course you can test it with doktypes or something else.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #233 
