### PR TITLE
[BUGFIX] Refactor sitemap for multiple bugfixes

### DIFF
--- a/Classes/UserFunc/SitemapXml.php
+++ b/Classes/UserFunc/SitemapXml.php
@@ -225,7 +225,8 @@ class SitemapXml
         return $this->getDb()->exec_SELECTgetRows(
             '*',
             'pages',
-            'uid IN(' . implode(',', $treeListArray) . ') ' . ($sitemapSettings['additionalWhere'] ?: ''),
+            'uid IN(' . implode(',', $treeListArray) . ') AND no_index=0 '
+            . ($sitemapSettings['additionalWhere'] ?: ''),
             '',
             'uid ASC'
         );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Sitemap refactored
* Pages are now collected in the same way CMS9 does it
* Records are now not displayed if the URL is not generated

## Relevant technical choices:

* For CMS7 compatibility, there is a check if the ConnectionPool exists.

## Test instructions

This PR can be tested by following these steps:

* Having an installation with pages (mountpoints, storage folders etc.) and records (fe. news) and visit the sitemap to see if it all works.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #233 #230 #228 #215 
