### PR TITLE
[FEATURE] Enable snippet preview for hidden pages

### DIFF
--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -40,10 +40,8 @@ class PageRequestMiddleware implements MiddlewareInterface
      */
     protected function getRequestHash(): string
     {
-        return md5(
-            serialize([
-                $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
-            ])
+        return GeneralUtility::hmac(
+            GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')
         );
     }
 }

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+namespace YoastSeoForTypo3\YoastSeo\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\VisibilityAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class PageRequestMiddleware
+ * @package YoastSeoForTypo3\YoastSeo\Middleware
+ */
+class PageRequestMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process page request
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $serverParams = $request->getServerParams();
+        if (isset($serverParams['HTTP_X_YOAST_PAGE_REQUEST'])
+            && $serverParams['HTTP_X_YOAST_PAGE_REQUEST'] === $this->getRequestHash()) {
+            $context = GeneralUtility::makeInstance(Context::class);
+            $context->setAspect('visibility', new VisibilityAspect(true));
+        }
+        return $handler->handle($request);
+    }
+
+    /**
+     * Get request hash
+     *
+     * @return string
+     */
+    protected function getRequestHash(): string
+    {
+        return md5(
+            serialize([
+                $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
+            ])
+        );
+    }
+}

--- a/Classes/UserFunctions/SnippetPreview.php
+++ b/Classes/UserFunctions/SnippetPreview.php
@@ -95,6 +95,8 @@ class SnippetPreview
     }
 
     /**
+     * Get content from url
+     *
      * @param $uriToCheck
      * @return null|string
      * @throws \TYPO3\CMS\Core\Exception
@@ -103,7 +105,18 @@ class SnippetPreview
     {
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] = false;
         $report = [];
-        $content = GeneralUtility::getUrl($uriToCheck, 1, [], $report);
+        $content = GeneralUtility::getUrl(
+            $uriToCheck,
+            1,
+            [
+                'X-Yoast-Page-Request' => md5(
+                    serialize([
+                        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
+                    ])
+                )
+            ],
+            $report
+        );
         if ($report['http_code'] === 200) {
             return $content;
         }

--- a/Classes/UserFunctions/SnippetPreview.php
+++ b/Classes/UserFunctions/SnippetPreview.php
@@ -109,10 +109,8 @@ class SnippetPreview
             $uriToCheck,
             1,
             [
-                'X-Yoast-Page-Request' => md5(
-                    serialize([
-                        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
-                    ])
+                'X-Yoast-Page-Request' => GeneralUtility::hmac(
+                    $uriToCheck
                 )
             ],
             $report

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'frontend' => [
+        'yoast-seo-page-request' => [
+            'target' => \YoastSeoForTypo3\YoastSeo\Middleware\PageRequestMiddleware::class,
+            'before' => [
+                'typo3/cms-frontend/tsfe'
+            ],
+            'after' => [
+                'typo3/cms-frontend/eid'
+            ]
+        ]
+    ]
+];


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* It is now possible to get a valid snippet preview for hidden pages

## Relevant technical choices:

* The request to the frontend url now has an extra header, which is checked via a Middleware that sets the visibility aspect

## Test instructions

This PR can be tested by following these steps:

* Hide a page in the tree and see if the snippet preview works

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #218 