### PR TITLE
[WIP][FEATURE] Backport of full page analysis which was introduced in v4 for CMS9

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -144,14 +144,8 @@ class PageLayoutHeader
                 $domain = $protocol . '://' . $domainName;
             }
 
-            $previewDataUrl = vsprintf(
-                $domain . $this->configuration['previewUrlTemplate'],
-                array(
-                    $pageLayoutController->id,
-                    static::FE_PREVIEW_TYPE,
-                    $pageLayoutController->current_sys_language
-                )
-            );
+            $previewDataUrl = $domain . '/?type=' . static::FE_PREVIEW_TYPE . '&pageId=' . $pageLayoutController->id
+                . '&additionalParams=' . urlencode('&L=' . $pageLayoutController->current_sys_language);
         }
 
         $allowedDoktypes = YoastUtility::getAllowedDoktypes();

--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -232,9 +232,7 @@ class SnippetPreview extends AbstractNode
             }
         }
 
-        $linkParameters = [
-            'type' => self::FE_PREVIEW_TYPE
-        ];
+        $linkParameters = [];
 
         // language handling
         $languageField = isset($GLOBALS['TCA'][$this->table]['ctrl']['languageField'])
@@ -291,7 +289,8 @@ class SnippetPreview extends AbstractNode
         $previewDomain = BackendUtility::getViewDomain($previewPageId);
         $additionalParamsForUrl = GeneralUtility::implodeArrayForUrl('', $linkParameters, '', false, true);
 
-        return $previewDomain . $this->viewScript . $previewPageId . $additionalParamsForUrl;
+        return $previewDomain . '/?type=' . self::FE_PREVIEW_TYPE .
+            '&pageId=' . $previewPageId . '&additionalParams=' . urlencode($additionalParamsForUrl);
     }
 
     /**

--- a/Classes/UserFunc/SnippetPreview.php
+++ b/Classes/UserFunc/SnippetPreview.php
@@ -1,0 +1,185 @@
+<?php
+namespace YoastSeoForTypo3\YoastSeo\UserFunc;
+
+use TYPO3\CMS\Core\Exception;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Class SnippetPreview
+ * @package YoastSeoForTypo3\YoastSeo\UserFunctions
+ */
+class SnippetPreview
+{
+    /**
+     * Render function
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $pageId = (int)GeneralUtility::_GET('pageId');
+        $additionalParams = urldecode(GeneralUtility::_GET('additionalParams'));
+
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $uriToCheck = $cObj->typoLink_URL([
+            'parameter' => $pageId,
+            'additionalParams' => $additionalParams,
+            'forceAbsoluteUrl' => 1
+        ]);
+
+        try {
+            $content = $this->getContentFromUrl($uriToCheck);
+            $data = $this->getDataFromContent($content, $uriToCheck);
+        } catch (Exception $e) {
+            $data = ['error' => 'Could not read the url ' . $uriToCheck . ': ' . $e->getMessage()];
+        }
+
+        return json_encode($data);
+    }
+
+    /**
+     * Get data from content
+     *
+     * @param string $content
+     * @param string $uriToCheck
+     * @return array
+     */
+    protected function getDataFromContent($content, $uriToCheck)
+    {
+        $title = $body = $metaDescription = '';
+
+        $titleFound = preg_match("/<title[^>]*>(.*?)<\/title>/is", $content, $matchesTitle);
+        $descriptionFound = preg_match(
+            "/<meta[^>]*name=[\" | \']description[\"|\'][^>]*content=[\"]([^\"]*)[\"][^>]*>/i",
+            $content,
+            $matchesDescription
+        );
+        $bodyFound = preg_match("/<body[^>]*>(.*?)<\/body>/is", $content, $matchesBody);
+
+        if ($bodyFound) {
+            $body = $matchesBody[1];
+
+            preg_match_all(
+                '/<!--\s*?TYPO3SEARCH_begin\s*?-->.*?<!--\s*?TYPO3SEARCH_end\s*?-->/mis',
+                $body,
+                $indexableContents
+            );
+
+            if (is_array($indexableContents[0]) && !empty($indexableContents[0])) {
+                $body = implode($indexableContents[0], '');
+            }
+        }
+
+        if ($titleFound) {
+            $title = $matchesTitle[1];
+        }
+
+        if ($descriptionFound) {
+            $metaDescription = $matchesDescription[1];
+        }
+
+        $url = preg_replace('/\/$/', '', $uriToCheck);
+
+        $titlePrependAppend = $this->getPageTitlePrependAppend();
+        if ($content !== null) {
+            return [
+                'id' => $GLOBALS['TSFE']->id,
+                'url' => $url,
+                'baseUrl' => preg_replace('/' . preg_quote($GLOBALS['TSFE']->page['slug'], '/') . '$/', '', $url),
+                'slug' => '/',
+                'title' => $title,
+                'description' => $metaDescription,
+                'locale' => isset($GLOBALS['TSFE']->config['config']['locale_all']) ? $GLOBALS['TSFE']->config['config']['locale_all'] : 'en_US.UTF-8',
+                'body' => $body,
+                'pageTitlePrepend' => $titlePrependAppend['prepend'],
+                'pageTitleAppend' => $titlePrependAppend['append'],
+            ];
+        }
+        return ['error' => 'Could not read the url ' . $uriToCheck];
+    }
+
+    /**
+     * Get content from url
+     *
+     * @param $uriToCheck
+     * @return null|string
+     * @throws \TYPO3\CMS\Core\Exception
+     */
+    protected function getContentFromUrl($uriToCheck)
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] = false;
+        $report = [];
+        $content = GeneralUtility::getUrl(
+            $uriToCheck,
+            1,
+            [
+                'X-Yoast-Page-Request' => md5(
+                    serialize([
+                        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
+                    ])
+                )
+            ],
+            $report
+        );
+        if ($report['http_code'] === 200) {
+            return $content;
+        }
+        throw new Exception($report['message']);
+    }
+
+    /**
+     * Get page title prepend append
+     *
+     * @return array
+     */
+    protected function getPageTitlePrependAppend()
+    {
+        $prependAppend = ['prepend' => '', 'append' => ''];
+        $siteTitle = trim(isset($GLOBALS['TSFE']->tmpl->setup['sitetitle']) ? $GLOBALS['TSFE']->tmpl->setup['sitetitle'] : '');
+        $pageTitleFirst = (bool)(isset($GLOBALS['TSFE']->config['config']['pageTitleFirst']) ?: false);
+        $pageTitleSeparator = $this->getPageTitleSeparator();
+        // only show a separator if there are both site title and page title
+        if ($siteTitle === '') {
+            $pageTitleSeparator = '';
+        } elseif (empty($pageTitleSeparator)) {
+            // use the default separator if non given
+            $pageTitleSeparator = ': ';
+        }
+
+        if ($pageTitleFirst) {
+            $prependAppend['append'] = $pageTitleSeparator . $siteTitle;
+        } else {
+            $prependAppend['prepend'] = $siteTitle . $pageTitleSeparator;
+        }
+
+        return $prependAppend;
+    }
+
+    /**
+     * Get page title separator
+     *
+     * @return string
+     */
+    protected function getPageTitleSeparator()
+    {
+        $pageTitleSeparator = '';
+        // Check for a custom pageTitleSeparator, and perform stdWrap on it
+        if (isset($GLOBALS['TSFE']->config['config']['pageTitleSeparator'])
+            && $GLOBALS['TSFE']->config['config']['pageTitleSeparator'] !== '') {
+            $pageTitleSeparator = $GLOBALS['TSFE']->config['config']['pageTitleSeparator'];
+
+            if (isset($GLOBALS['TSFE']->config['config']['pageTitleSeparator.'])
+                && is_array($GLOBALS['TSFE']->config['config']['pageTitleSeparator.'])) {
+                $pageTitleSeparator = $GLOBALS['TSFE']->cObj->stdWrap(
+                    $pageTitleSeparator,
+                    $GLOBALS['TSFE']->config['config']['pageTitleSeparator.']
+                );
+            } else {
+                $pageTitleSeparator .= ' ';
+            }
+        }
+
+        return $pageTitleSeparator;
+    }
+}

--- a/Configuration/TypoScript/Setup/Preview.typoscript
+++ b/Configuration/TypoScript/Setup/Preview.typoscript
@@ -6,10 +6,11 @@ yoast_seo_preview {
         absRefPrefix = /
 
         no_cache = 1
+        typolinkEnableLinksAcrossDomains = 1
 
         additionalHeaders {
             10 {
-                header = Content-type: text/xml; charset=UTF-8
+                header = Content-type: application/json; charset=UTF-8
             }
 
             20 {
@@ -18,79 +19,6 @@ yoast_seo_preview {
         }
     }
 
-    wrap = <?xml version="1.0" encoding="UTF-8"?><preview>|</preview>
-
-    20 = COA
-    20 {
-        10 =< lib.yoastSEO.currentURL
-        10.wrap = <url>|</url>
-
-        20 =< lib.yoastSEO.pageTitleComplete
-        20 {
-            stdWrap.wrap = <title><![CDATA[|]]></title>
-        }
-
-        30 =< lib.yoastSEO.pageTitle
-        30 {
-            stdWrap.wrap = <pageTitle><![CDATA[|]]></pageTitle>
-        }
-
-        31 =< lib.yoastSEO.pageTitlePrepend
-        31 {
-            stdWrap.wrap = <pageTitlePrepend><![CDATA[|]]></pageTitlePrepend>
-        }
-
-        32 =< lib.yoastSEO.pageTitleAppend
-        32 {
-            stdWrap.wrap = <pageTitleAppend><![CDATA[|]]></pageTitleAppend>
-        }
-
-        40 =< lib.yoastSEO.description
-        40.wrap = <description><![CDATA[|]]></description>
-
-        50 =< lib.yoastSEO.locale
-        50.wrap = <locale>|</locale>
-
-        60 =< lib.yoastSEO.slug
-        60.wrap = <slug>|</slug>
-
-        wrap = <meta>|</meta>
-    }
-
-    30 = CONTENT
-    30 {
-        table = tt_content
-
-        select {
-            where = colPos >= 0
-            orderBy = sorting
-        }
-        renderObj =< tt_content
-        renderObj.stdWrap {
-            wrap = <element><![CDATA[|]]></element>
-            replacement {
-                10.search.char = 10
-                10.replace =
-
-                # remove CDATA Objects inside the element, see Issue #85
-                20.search = <![CDATA[
-                20.replace =
-                30.search = ]]>
-                30.replace =
-
-                # remove script tags and content
-                40.search = #<script\b[^>]*>(.*?)<\/script>#is
-                40.replace =
-                40.useRegExp = 1
-
-                # remove style tags and content
-                50.search = #<style\b[^>]*>(.*?)<\/style>#is
-                50.replace =
-                50.useRegExp = 1
-            }
-            required = 1
-
-        }
-        wrap = <content>|</content>
-    }
+    10 = USER_INT
+    10.userFunc = YoastSeoForTypo3\YoastSeo\UserFunc\SnippetPreview->render
 }

--- a/Resources/Public/JavaScript/Tca.js
+++ b/Resources/Public/JavaScript/Tca.js
@@ -19,7 +19,6 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
         $formEngineDescription.after("<div class='yoast-progressbars-container'><progress id='yoast-progress-description' class='yoast-progressbars'></progress></div>");
 
         previewRequest.done(function (previewDocument) {
-            console.log(previewDocument);
             var $snippetPreviewElement = $targetElement.append('<div class="snippetPreview yoastPanel" />').find('.snippetPreview');
 
             var pageContent = previewDocument.body;

--- a/Resources/Public/JavaScript/Tca.js
+++ b/Resources/Public/JavaScript/Tca.js
@@ -19,36 +19,27 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
         $formEngineDescription.after("<div class='yoast-progressbars-container'><progress id='yoast-progress-description' class='yoast-progressbars'></progress></div>");
 
         previewRequest.done(function (previewDocument) {
+            console.log(previewDocument);
             var $snippetPreviewElement = $targetElement.append('<div class="snippetPreview yoastPanel" />').find('.snippetPreview');
 
-            // the preview is an XML document, for easy traversal convert it to a jQuery object
-            var $previewDocument = $(previewDocument);
-            var $metaSection = $previewDocument.find('meta');
-            var $contentElements = $previewDocument.find('content>element');
-
-            var pageContent = '';
-            $contentElements.each(function (index, element) {
-                pageContent += element.textContent;
-            });
-
-            var slug = $metaSection.find('slug').text().replace(/^\/|\/$/g, '');
+            var pageContent = previewDocument.body;
 
             var snippetPreview = new YoastSEO.SnippetPreview({
                 data: {
-                    title: $metaSection.find('title').text(),
-                    metaDesc: $metaSection.find('description').text(),
-                    urlPath: slug
+                    title: previewDocument.title,
+                    metaDesc: previewDocument.description,
+                    urlPath: previewDocument.slug
                 },
-                baseURL: $metaSection.find('url').text().replace($metaSection.find('slug').text(), '/'),
+                baseURL: previewDocument.baseUrl,
                 placeholder: {
-                    title: $metaSection.find('pageTitle').text(),
-                    urlPath: slug
+                    title: previewDocument.title,
+                    urlPath: previewDocument.slug
                 },
                 targetElement: $snippetPreviewElement.get(0),
                 previewMode: 'desktop'
             });
 
-            $formEngineTitle.attr('placeholder', $metaSection.find('pageTitle').text());
+            $formEngineTitle.attr('placeholder', previewDocument.title);
 
             var apps = [];
             var cnt = 0;
@@ -74,7 +65,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                         callbacks: {
                             getData: function () {
                                 return {
-                                    title: $metaSection.find('title').text(),
+                                    title: previewDocument.title,
                                     text: pageContent,
                                     keyword: focusKeywordElement.val()
                                 };
@@ -107,7 +98,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                                 $yoastSeoScoreBarReadability.find('.wpseo-score-textual').first().html(scoreTextual);
                             }
                         },
-                        locale: $metaSection.find('locale').text(),
+                        locale: previewDocument.locale,
                         translations: (window.tx_yoast_seo !== undefined && window.tx_yoast_seo !== null && window.tx_yoast_seo.translations !== undefined ? window.tx_yoast_seo.translations : null)
                     });
 
@@ -129,7 +120,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                         callbacks: {
                             getData: function () {
                                 return {
-                                    title: $metaSection.find('title').text(),
+                                    title: previewDocument.title,
                                     text: pageContent,
                                     keyword: tx_yoast_seo.firstFocusKeyword
                                 };
@@ -157,7 +148,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                                 $yoastSeoScoreBarReadability.find('.wpseo-score-textual').first().html(scoreTextual);
                             }
                         },
-                        locale: $metaSection.find('locale').text(),
+                        locale: previewDocument.locale,
                         translations: (window.tx_yoast_seo !== undefined && window.tx_yoast_seo !== null && window.tx_yoast_seo.translations !== undefined ? window.tx_yoast_seo.translations : null)
                     });
 
@@ -172,7 +163,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
 
             initApps();
 
-            $('*[data-yoast-trigger="true"]').trigger('dataReceived', [pageContent, $metaSection.find('locale').text()]);
+            $('*[data-yoast-trigger="true"]').trigger('dataReceived', [pageContent, previewDocument.locale]);
 
             var $focusKeywordPremiumPanel = $('div[id*="tx_yoastseo_focuskeyword_premium"]').find('.panel');
 
@@ -197,7 +188,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
 
             $formEngineTitle.on('input', function() {
                 var $titleElement = $targetElement.find('#snippet-editor-title');
-                var $newTitle = $metaSection.find('pageTitlePrepend').text() + $(this).val() + $metaSection.find('pageTitleAppend').text()
+                var $newTitle = previewDocument.pageTitlePrepend + $(this).val() + previewDocument.pageTitleAppend;
                 $titleElement.val($newTitle.trim());
 
                 snippetPreview.changedInput();

--- a/Resources/Public/JavaScript/app.js
+++ b/Resources/Public/JavaScript/app.js
@@ -52,29 +52,19 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
             $snippetPreview.attr('id', 'snippet');
 
             // the preview is an XML document, for easy traversal convert it to a jQuery object
-            var $previewDocument = $(previewDocument);
-            var $metaSection = $previewDocument.find('meta');
-            var $contentElements = $previewDocument.find('content>element');
-
-            var pageContent = '';
-
-            $contentElements.each(function (index, element) {
-                pageContent += element.textContent;
-            });
-
+            var pageContent = previewDocument.body;
             var $focusKeywordElement = $('#' + tx_yoast_seo.settings.targetElementId + '_focusKeyword');
-
-            var slug = $metaSection.find('slug').text().replace(/^\/|\/$/g, '');
 
             var snippetPreview = new YoastSEO.SnippetPreview({
                 data: {
-                    title: $metaSection.find('title').text(),
-                    metaDesc: $metaSection.find('description').text(),
-                    urlPath: slug
+                    title: previewDocument.title,
+                    metaDesc: previewDocument.description,
+                    urlPath: previewDocument.slug
                 },
-                baseURL: $metaSection.find('url').text().replace($metaSection.find('slug').text(), '/'),
+                baseURL: previewDocument.baseUrl,
                 placeholder: {
-                    urlPath: slug
+                    title: previewDocument.title,
+                    urlPath: previewDocument.slug
                 },
                 targetElement: $snippetPreview.get(0),
                 callbacks: {
@@ -95,7 +85,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                 callbacks: {
                     getData: function () {
                         return {
-                            title: $metaSection.find('title').text(),
+                            title: previewDocument.title,
                             keyword: tx_yoast_seo.settings.focusKeyword,
                             text: pageContent
                         };
@@ -129,7 +119,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                         $('#yoastSeo-score-bar-readability').find('.wpseo-score-textual').first().html(scoreTextual);
                     }
                 },
-                locale: $metaSection.find('locale').text(),
+                locale: previewDocument.locale,
                 translations: (window.tx_yoast_seo !== undefined && window.tx_yoast_seo !== null && window.tx_yoast_seo.translations !== undefined ? window.tx_yoast_seo.translations : null)
             });
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Backport to v3 of the full page analysis which was introduced in v4 for CMS9

## Relevant technical choices:

* Since it's not (easily) possible to generate a frontend url in the backend, the id and additionalParams are sent to the frontend script which generates the url to check.

## Test instructions

This PR can be tested by following these steps:

* Install in a CMS7 or CMS8 version and take a look in the page module or page properties.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #134 #177 

**WIP**
This is a work in progress, it has not been tested with:
- tca of records
- multi domain
- multi language

And these properties within the returned json require extra attention:
- url
- baseUrl
- slug
- locale