### PR TITLE
[BUGFIX] Fix HTML markup in modals, resolves #240

### DIFF
--- a/Resources/Public/JavaScript/app.js
+++ b/Resources/Public/JavaScript/app.js
@@ -116,7 +116,7 @@ define(['jquery', './bundle', 'TYPO3/CMS/Backend/AjaxDataHandler', 'TYPO3/CMS/Ba
                             }
 
                             var title = $(this).find('.yoastSeo-score-bar-item--title').text();
-                            var content = cssFile + preContent + $(this).find('.yoastSeo-score-bar-item--content').html();
+                            var content = $(cssFile + preContent + $(this).find('.yoastSeo-score-bar-item--content').html());
 
                             Modal.show(title, content);
                         });


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix broken HTML markup in modals, caused by TYPO3 security update (TYPO3 v9.5.2)

## Relevant technical choices:

* Modal.js escapes all content of type string ([see](https://github.com/TYPO3/TYPO3.CMS/commit/c35646c3f7795a4a7b0046a88f146b490fa4883c#diff-4a9e6a863b7911f490c3abb65fb10e01R239)), I therefore wrapped the HTML markup in a new jQuery object.

## Test instructions

This PR can be tested by following these steps:

* Install latest TYPO3 v9
* Check modal before / after PR

Tested the change with TYPO3 v9.5.1 (before security update) and TYPO3 v9.5.4 (after security update). Change also works in TYPO3 v8 (tested v8.7.22) and should therefore be cherry picked in release/3.0 branch.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #240 