### PR TITLE
[BUGFIX] Fix TCA to address strict mysql compatibility

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -218,7 +218,8 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
             'label' => '',
             'exclude' => true,
             'config' => [
-                'type' => 'text',
+                'type' => 'input',
+                'default' => 0,
                 'renderType' => 'cornerstone'
             ]
         ],

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -165,7 +165,8 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
             'label' => '',
             'exclude' => true,
             'config' => [
-                'type' => 'text',
+                'type' => 'input',
+                'default' => 0,
                 'renderType' => 'cornerstone'
             ]
         ],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed yoast `pages` TCA by providing an integer as default value for `tx_yoastseo_cornerstone`

## Relevant technical choices:

*  `tx_yoastseo_cornerstone` is stored as an integer in the database, therefore its type shouldn't be `text` (meant for multi line text input)
* If no default value is provided, Typo3 tries to insert an empty string. With a MySQL database running in strict mode, it causes an error and prevents pages to be saved.

## Test instructions

This PR can be tested by following these steps:

* Install Typo3 8.7 with Yoast and a MySQL database in strict mode
* Create a new record of type page 

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
