### PR TITLE
[BUGFIX] Force type casts to avoid type hint errors

### DIFF
--- a/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
+++ b/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
@@ -103,7 +103,7 @@ class BreadcrumbStructuredDataProvider implements StructuredDataProviderInterfac
     protected function getUrlForPage($pageId): string
     {
         if (class_exists(SiteFinder::class)) {
-            $site = $this->siteFinder->getSiteByPageId($pageId);
+            $site = $this->siteFinder->getSiteByPageId((int)$pageId);
 
             return (string)$site->getRouter()->generateUri($pageId, ['_language' => $this->getLanguage()]);
         }

--- a/Classes/StructuredData/SiteStructuredDataProvider.php
+++ b/Classes/StructuredData/SiteStructuredDataProvider.php
@@ -54,12 +54,12 @@ class SiteStructuredDataProvider implements StructuredDataProviderInterface
     public function getData(): array
     {
         $data = [];
-        if ($this->tsfe->page['is_siteroot'] === 1) {
+        if ((int)$this->tsfe->page['is_siteroot'] === 1) {
             $data[] = [
                 '@context' => 'https://www.schema.org',
                 '@type' => 'WebSite',
-                'url' => $this->getUrl($this->tsfe->page['uid']),
-                'name' => $this->getName($this->tsfe->page['uid']),
+                'url' => $this->getUrl((int)$this->tsfe->page['uid']),
+                'name' => $this->getName((int)$this->tsfe->page['uid']),
             ];
         }
 


### PR DESCRIPTION
The data used in the structured data providers needs to be cast for further
usage in the methods.

## Summary

This PR can be summarized in the following changelog entry:

*  Force type casts to avoid type hint errors

## Relevant technical choices:

* Just add some type casts because the data is delivered as string but expected as integer by the calling methods.

## Test instructions

This PR can be tested by following these steps:

* Install the current master inside TYPO3 9.5.5 with PHP 7.2
* Call the frontend, you should run into a PHP error.
* After applying this patch, you should get the rendered json-ld from the structured data providers

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #264 
