### PR TITLE
[BUGFIX] Ignore pages for breadcrumb which are not in a site root

### DIFF
--- a/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
+++ b/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
@@ -56,8 +56,10 @@ class BreadcrumbStructuredDataProvider implements StructuredDataProviderInterfac
         $excludedDoktypes = $this->configuration['excludedDoktypes'] ? GeneralUtility::intExplode(',', $this->configuration['excludedDoktypes']) : [];
         $breadcrumbs = [];
         $iterator = 1;
+        $siteRootFound = false;
         foreach ($rootLine as $k => $page) {
-            if (!in_array((int)$page['doktype'], $excludedDoktypes, true)) {
+            $siteRootFound = $siteRootFound || $page['is_siteroot'];
+            if ($siteRootFound && !in_array((int)$page['doktype'], $excludedDoktypes, true)) {
                 $breadcrumbs[] = [
                     '@type' => 'ListItem',
                     'position' => $iterator,


### PR DESCRIPTION
If you have a page at the root level for e.g. some global configuration
the building of the breadcrumb will fail because this site has no site
configuration.

To solve this issue only pages which are inside a site root should be
processed.

## Summary

This PR can be summarized in the following changelog entry:

* Ignore pages for breadcrumb which are not in a site root

## Relevant technical choices:

* 

## Test instructions

This PR can be tested by following these steps:

* Create a page (called **Root**) at the top level which is **not** a site root (has no Site Configuration)
* Create on ore multiple pages with Site Configuration **in** the **Root** page

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
