### PR TITLE
Bugfix/middleware cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ We will follow [Semantic Versioning](http://semver.org/).
 ## Yoast SEO Premium for TYPO3
 Besides the free version of our plugin, we also have a premium version. The free version enables you to do all necessary optimizations. With the premium version, we make it even easier to do! More information can be found on https://www.maxserv.com/yoast.
 
+## Unreleased
+### Fixed
+* Prevent caching of page if Middleware is active
+
 ## 5.0.1 May 2, 2019
 ### Changed
 * Updated Yoast libraries

--- a/Classes/Frontend/UsePageCache.php
+++ b/Classes/Frontend/UsePageCache.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace YoastSeoForTypo3\YoastSeo\Frontend;
 
-use YoastSeoForTypo3\YoastSeo\Utility\YoastReguestHash;
+use YoastSeoForTypo3\YoastSeo\Utility\YoastRequestHash;
 
 /**
  * Class UsePageCache
@@ -17,7 +17,7 @@ class UsePageCache
      */
     public function usePageCache($pObj, $usePageCache): bool
     {
-        if (YoastReguestHash::isValid($GLOBALS['TYPO3_REQUEST']->getServerParams())) {
+        if (YoastRequestHash::isValid($GLOBALS['TYPO3_REQUEST']->getServerParams())) {
             return false;
         }
         return $usePageCache;

--- a/Classes/Frontend/UsePageCache.php
+++ b/Classes/Frontend/UsePageCache.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace YoastSeoForTypo3\YoastSeo\Frontend;
+
+use YoastSeoForTypo3\YoastSeo\Utility\YoastReguestHash;
+
+/**
+ * Class UsePageCache
+ * @package YoastSeoForTypo3\YoastSeo\Frontend
+ */
+class UsePageCache
+{
+    /**
+     * @param \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $pObj
+     * @param bool $usePageCache
+     * @return bool
+     */
+    public function usePageCache($pObj, $usePageCache): bool
+    {
+        if (YoastReguestHash::isValid($GLOBALS['TYPO3_REQUEST']->getServerParams())) {
+            return false;
+        }
+        return $usePageCache;
+    }
+}

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -8,6 +8,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use YoastSeoForTypo3\YoastSeo\Utility\YoastReguestHash;
 
 /**
  * Class PageRequestMiddleware
@@ -24,24 +25,10 @@ class PageRequestMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $serverParams = $request->getServerParams();
-        if (isset($serverParams['HTTP_X_YOAST_PAGE_REQUEST'])
-            && $serverParams['HTTP_X_YOAST_PAGE_REQUEST'] === $this->getRequestHash()) {
+        if (YoastReguestHash::isValid($request->getServerParams())) {
             $context = GeneralUtility::makeInstance(Context::class);
             $context->setAspect('visibility', new VisibilityAspect(true));
         }
         return $handler->handle($request);
-    }
-
-    /**
-     * Get request hash
-     *
-     * @return string
-     */
-    protected function getRequestHash(): string
-    {
-        return GeneralUtility::hmac(
-            GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')
-        );
     }
 }

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -8,7 +8,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use YoastSeoForTypo3\YoastSeo\Utility\YoastReguestHash;
+use YoastSeoForTypo3\YoastSeo\Utility\YoastRequestHash;
 
 /**
  * Class PageRequestMiddleware
@@ -25,7 +25,7 @@ class PageRequestMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (YoastReguestHash::isValid($request->getServerParams())) {
+        if (YoastRequestHash::isValid($request->getServerParams())) {
             $context = GeneralUtility::makeInstance(Context::class);
             $context->setAspect('visibility', new VisibilityAspect(true));
         }

--- a/Classes/Utility/YoastReguestHash.php
+++ b/Classes/Utility/YoastReguestHash.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+namespace YoastSeoForTypo3\YoastSeo\Utility;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class YoastReguestHash
+ * @package YoastSeoForTypo3\YoastSeo\Utility
+ */
+class YoastReguestHash
+{
+    /**
+     * @param $serverParams
+     * @return bool
+     */
+    public static function isValid($serverParams): bool
+    {
+        return isset($serverParams['HTTP_X_YOAST_PAGE_REQUEST'])
+            && $serverParams['HTTP_X_YOAST_PAGE_REQUEST'] === GeneralUtility::hmac(
+                GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')
+            );
+    }
+}

--- a/Classes/Utility/YoastRequestHash.php
+++ b/Classes/Utility/YoastRequestHash.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Class YoastReguestHash
  * @package YoastSeoForTypo3\YoastSeo\Utility
  */
-class YoastReguestHash
+class YoastRequestHash
 {
     /**
      * @param $serverParams

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -10,6 +10,9 @@ if (version_compare(TYPO3_branch, '9.5', '<')) {
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-postProcess'][]
         = \YoastSeoForTypo3\YoastSeo\Frontend\PageTitle::class . '->render';
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['usePageCache'][]
+        = \YoastSeoForTypo3\YoastSeo\Frontend\UsePageCache::class;
 }
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptConstants(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Now, when the middleware is active, the pages does not get cached so hidden pages do not end up in the cache

## Relevant technical choices:

* Make usage of the `usePageCache` hook to check if the middleware is active

## Test instructions

This PR can be tested by following these steps:

* Before you pull this branch, create a hidden page, then edit an existing active page and see if the hidden page ends up in a menu
* Then pull this branch and see if the problem is fixed

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #272
