### PR TITLE
[BUGFIX] Fixed PagesWithoutDescription overview for CMS8, only overlay was checked

### DIFF
--- a/Classes/DataProviders/PagesWithoutDescriptionOverviewDataProvider.php
+++ b/Classes/DataProviders/PagesWithoutDescriptionOverviewDataProvider.php
@@ -35,8 +35,10 @@ class PagesWithoutDescriptionOverviewDataProvider extends AbstractOverviewDataPr
 
         if (version_compare(TYPO3_branch, '9.5', '>=')) {
             $table = 'pages';
-        } else {
+        } elseif ((int)$this->callerParams['language'] > 0) {
             $table = 'pages_language_overlay';
+        } else {
+            $table = 'pages';
         }
 
         $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
@@ -47,9 +49,12 @@ class PagesWithoutDescriptionOverviewDataProvider extends AbstractOverviewDataPr
                 $qb->expr()->isNull('description')
             ),
             $qb->expr()->in('doktype', $doktypes),
-            $qb->expr()->eq('sys_language_uid', (int)$this->callerParams['language']),
             $qb->expr()->eq('tx_yoastseo_hide_snippet_preview', 0)
         ];
+
+        if (version_compare(TYPO3_branch, '9.5', '>=') || $table === 'pages_language_overlay') {
+            $constraints[] = $qb->expr()->eq('sys_language_uid', (int)$this->callerParams['language']);
+        }
 
         $query = $qb->select('*')
             ->from($table)


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With the release of version 5 (a merge from the CMS8 and CMS9 version), the overview in the backend for pages without meta description was only checking the pages_language_overlay table for CMS8. This fixes it.

## Relevant technical choices:

* Instead of checking for CMS8 version, I just added an elseif so it only checks if not CMS9.

## Test instructions

This PR can be tested by following these steps:

* Within a CMS8 installation with multiple languages, check if the normal pages (default language) also outputs pages without description.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #280 
