### PR TITLE
[BUGFIX] Generate absolute url when the site base is only a slash

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -347,12 +347,12 @@ class PageLayoutHeader
                     $additionalQueryParams = [];
                     parse_str($additionalGetVars, $additionalQueryParams);
                     $additionalQueryParams['_language'] = $site->getLanguageById($languageId);
-                    $uriToCheck = (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams);
+                    $uriToCheck = YoastUtility::fixAbsoluteUrl((string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams));
 
                     unset($additionalQueryParams);
                     $additionalQueryParams['type'] = self::FE_PREVIEW_TYPE;
                     $additionalQueryParams['uriToCheck'] = urlencode($uriToCheck);
-                    $uri = (string)$site->getRouter()->generateUri($site->getRootPageId(), $additionalQueryParams);
+                    $uri = YoastUtility::fixAbsoluteUrl((string)$site->getRouter()->generateUri($site->getRootPageId(), $additionalQueryParams));
                 } else {
                     $uri = CMS\Backend\Utility\BackendUtility::getPreviewUrl($finalPageIdToShow, '', $rootLine, '', '', $additionalGetVars);
                 }

--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -501,12 +501,12 @@ class SnippetPreview extends AbstractNode
                     $additionalQueryParams = [];
                     parse_str($additionalGetVars, $additionalQueryParams);
                     $additionalQueryParams['_language'] = $site->getLanguageById($languageId);
-                    $uriToCheck = (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams);
+                    $uriToCheck = YoastUtility::fixAbsoluteUrl((string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams));
 
                     unset($additionalQueryParams);
                     $additionalQueryParams['type'] = self::FE_PREVIEW_TYPE;
                     $additionalQueryParams['uriToCheck'] = urlencode($uriToCheck);
-                    $uri = (string)$site->getRouter()->generateUri($site->getRootPageId(), $additionalQueryParams);
+                    $uri = YoastUtility::fixAbsoluteUrl((string)$site->getRouter()->generateUri($site->getRootPageId(), $additionalQueryParams));
                 } else {
                     $uri = BackendUtility::getPreviewUrl($finalPageIdToShow, '', $rootLine, '', '', $additionalGetVars);
                 }

--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -15,6 +15,7 @@ namespace YoastSeoForTypo3\YoastSeo\Utility;
  */
 
 use TYPO3\CMS;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class YoastUtility
@@ -234,5 +235,19 @@ class YoastUtility
     public static function getUrlForType($type): string
     {
         return '/?type=' . $type;
+    }
+
+    /**
+     * Fix absolute url when site configuration has '/' as base
+     *
+     * @param string $url
+     * @return string
+     */
+    public static function fixAbsoluteUrl(string $url): string
+    {
+        if (strpos($url, '/') === 0) {
+            $url = GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . $url;
+        }
+        return $url;
     }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* When the base in site configuration is only `/`, the absolute URL was not generated in the backend. This fix always provides a full url.

## Relevant technical choices:

* When the generated URL has a slash at the first position, the TYPO3_REQUEST_HOST is prepended.

## Test instructions

This PR can be tested by following these steps:

* Set your site base to `/` and see if the snippet preview in the page module and page properties still shows results.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #279
