### PR TITLE
[TASK] Migrated documentation to new infrastructure

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,0 +1,82 @@
+# coding: utf-8
+
+[general]
+
+# .................................................................................
+# ...   (required) title (displayed in left sidebar (desktop) or top panel (mobile)
+# .................................................................................
+
+project     = Yoast SEO for TYPO3
+
+# .................................................................................
+# ...   (recommended) version, displayed next to title (desktop) and in <meta name="book-version"
+# .................................................................................
+
+release     = latest
+
+# .................................................................................
+# ...  (recommended) displayed in footer
+# .................................................................................
+
+copyright   = since 2016 by MaxServ and Yoast
+
+[html_theme_options]
+
+# .................................................................................
+# ...  (recommended) to get the "Edit me on Github Button"
+# .................................................................................
+
+github_branch        = master
+github_repository    = Yoast/Yoast-SEO-for-TYPO3
+
+
+# .................................................................................
+# ...  (recommended) Fill in values to get links in the "Related Links" section
+# .................................................................................
+
+# usually an email address
+project_contact      = support@yoast.com
+
+# URL of online discussions, you can leave this blank
+project_discussions  =
+
+# URL of webpage of your extension (if it has one)
+project_home         = https://yoast.com/typo3-extensions-seo/
+
+# URL to Issues
+project_issues       = https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues
+
+# URL of repository
+project_repository   = https://github.com/Yoast/Yoast-SEO-for-TYPO3
+
+
+[intersphinx_mapping]
+
+# .................................................................................
+# for cross-referencing across manuals (intersphinx) with :ref:
+#
+# You must uncomment all manuals you use in your cross-references
+#
+# Example usage:
+#   :ref:`t3contribute:start` will link to start page of Contribution Guide
+# .................................................................................
+
+h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
+# t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
+# t3editors     = https://docs.typo3.org/m/typo3/tutorial-editors/master/en-us/
+# t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/Index.html
+# t3install     = https://docs.typo3.org/m/typo3/guide-installation/master/en-us/
+# t3l10n        = https://docs.typo3.org/m/typo3/guide-frontendlocalization/master/en-us/
+# t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/
+# t3sitepackage = https://docs.typo3.org/m/typo3/tutorial-sitepackage/master/en-us/
+# t3tca         = https://docs.typo3.org/m/typo3/reference-tca/master/en-us/
+# t3templating  = https://docs.typo3.org/m/typo3/tutorial-templating-with-fluid/master/en-us/
+# t3ts45        = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/
+# t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
+t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
+
+[extensions]
+
+# This is required for embedding YouTube videos
+
+any_name_youtube = sphinxcontrib.youtube


### PR DESCRIPTION
Migrated the documentation to the new infrastructure of the docs.typo3.org.
See https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/WritingDocForExtension/Migrate.html
for more information.