### PR TITLE
Bugfix/283 getalloweddoktypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ We will follow [Semantic Versioning](http://semver.org/).
 Besides the free version of our plugin, we also have a premium version. The free version enables you to do all necessary optimizations. With the premium version, we make it even easier to do! More information can be found on https://www.maxserv.com/yoast.
 
 ## Unreleased
+### Changed
+* You can set the doktypes that Yoast should analyse now by `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']` in stead of TypoScript. It will still have a fallback to the old TypoScript configuration. ([#283](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/283))
+* Altered the [documentation](https://docs.typo3.org/p/yoast-seo-for-typo3/yoast_seo/master/en-us/) a little bit.
+
 ### Fixed
-* Prevent caching of page if Middleware is active
+* Restored the compatibility with PHP 7.0 ([#266](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/266))
+* Prevent caching of page when analysing a page that is disabled. ([#272](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/272))
+* When the base in site configuration is only `/`, the absolute URL (which is needed by the analysis) will now be based on the current domain. [#279](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/279)
+* Made sure that if you set the allowed doktypes via `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']`, the doktypes will always be available when defining which fields in the page properties.  ([#283](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/283))  
 
 ## 5.0.1 May 2, 2019
 ### Changed

--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -36,31 +36,32 @@ class YoastUtility
      */
     public static function getAllowedDoktypes($configuration = null, $returnInString = false)
     {
-        // By default only add normal pages
-        $allowedDoktypes = [];
+        $allowedDoktypes = array_values($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
 
-        if ($configuration === null) {
-            $configuration = self::getTypoScriptConfiguration();
-        }
+        if (empty($allowedDoktypes)) {
+            if ($configuration === null) {
+                $configuration = self::getTypoScriptConfiguration();
+            }
 
-        if (is_array($configuration) &&
-            array_key_exists('allowedDoktypes', $configuration) &&
-            is_array($configuration['allowedDoktypes'])
-        ) {
-            foreach ($configuration['allowedDoktypes'] as $doktype) {
-                if (!in_array($doktype, $allowedDoktypes)) {
-                    $allowedDoktypes[] = (int)$doktype;
+            if (is_array($configuration) &&
+                array_key_exists('allowedDoktypes', $configuration) &&
+                is_array($configuration['allowedDoktypes'])
+            ) {
+                foreach ($configuration['allowedDoktypes'] as $doktype) {
+                    if (!in_array($doktype, $allowedDoktypes)) {
+                        $allowedDoktypes[] = (int)$doktype;
+                    }
                 }
             }
-        }
 
-        $allowedDoktypes = ($allowedDoktypes) ?: [1];
+            $allowedDoktypes = $allowedDoktypes ?: [1];
+        }
 
         if ($returnInString) {
             return implode(',', $allowedDoktypes);
-        } else {
-            return $allowedDoktypes;
         }
+
+        return $allowedDoktypes;
     }
 
     /**

--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -36,10 +36,15 @@ class YoastUtility
      */
     public static function getAllowedDoktypes($configuration = null, $returnInString = false)
     {
-        $allowedDoktypes = array_values($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
+        $allowedDoktypes = array_values((array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
 
         if (empty($allowedDoktypes)) {
             if ($configuration === null) {
+                trigger_error(
+                    'You are using the old TypoScript way of setting the allowed doktypes. Check documentation on how to set the allowed doktypes correctly',
+                    E_USER_DEPRECATED
+                );
+
                 $configuration = self::getTypoScriptConfiguration();
             }
 

--- a/Configuration/TypoScript/Setup/Module.typoscript
+++ b/Configuration/TypoScript/Setup/Module.typoscript
@@ -1,10 +1,5 @@
 module.tx_yoastseo {
     settings {
-        allowedDoktypes {
-            page = 1
-            backend_user_section = 6
-        }
-
         itemsPerPage = 20
 
         og < plugin.tx_yoastseo.settings.og

--- a/Documentation/Configuration/SnippetPreview/Index.rst
+++ b/Documentation/Configuration/SnippetPreview/Index.rst
@@ -14,17 +14,15 @@ Snippet Preview
 Enable snippet preview on specific page types
 ---------------------------------------------
 By default, the snippet preview is only shown on pages with doktype 1 (Standard page) and 6 (Backend user section). You can
-add your own doktypes like the example below to your TypoScript setup.
+add your own doktypes like the example below by adding a doktype to the :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']`
+array.
 
-.. code-block:: typoscript
+.. code-block:: php
 
-    module.tx_yoastseo {
-        settings {
-            allowedDoktypes {
-                blog = 137
-            }
-        }
-    }
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']['blog'] = 137;
+
+The key can be any unique string. It is only used to identify the doktype as a developer. The value contains the numeric
+value of the doktype.
 
 Disable snippet preview with PageTs
 -----------------------------------

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -30,14 +30,14 @@ Yoast SEO for TYPO3
         SEO, Yoast, Readability, Analysis
 
     :Copyright:
-        |copyright|
+        since 2016 by MaxServ and Yoast
 
     :Author:
         MaxServ / Yoast
 
     :Support:
         Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
-        you want real support for your installation, you can buy our `premium plugin <|project_home|>`__ and get 24/7 support.
+        you want real support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
 
     :License:
         This document is published under the Open Publication License
@@ -49,6 +49,11 @@ Yoast SEO for TYPO3
     The content of this document is related to TYPO3,
     a GNU/GPL CMS/Framework available from `www.typo3.org <https://typo3.org/>`__.
 
+
+.. tip::
+
+    Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
+    you want real support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
 
     **Table of Contents**
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -55,7 +55,8 @@ Yoast SEO for TYPO3
     Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
     you want real support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
 
-    **Table of Contents**
+Table of Contents
+============
 
 .. toctree::
     :maxdepth: 3

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -37,7 +37,7 @@ Yoast SEO for TYPO3
 
     :Support:
         Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
-        you want real support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
+        you want support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
 
     :License:
         This document is published under the Open Publication License
@@ -53,10 +53,10 @@ Yoast SEO for TYPO3
 .. tip::
 
     Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
-    you want real support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
+    you want support for your installation, you can buy our `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7 support.
 
 Table of Contents
-============
+=================
 
 .. toctree::
     :maxdepth: 3

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -27,16 +27,17 @@ Yoast SEO for TYPO3
         Integrates text analysis and assessment from `YoastSEO.js <https://github.com/Yoast/YoastSEO.js>`__.
 
     :Keywords:
-        SEO, Yoast
+        SEO, Yoast, Readability, Analysis
 
     :Copyright:
-        2017
+        |copyright|
 
     :Author:
         MaxServ / Yoast
 
-    :Email:
-        suppport@maxserv.com
+    :Support:
+        Community support is available on `Slack <https://typo3.slack.com>`__ in the channel #yoast-seo-for-typo3. If
+        you want real support for your installation, you can buy our `premium plugin <|project_home|>`__ and get 24/7 support.
 
     :License:
         This document is published under the Open Publication License

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -35,7 +35,7 @@ github_repository    = Yoast/Yoast-SEO-for-TYPO3
 # .................................................................................
 
 # usually an email address
-project_contact      = support@yoast.com
+project_contact      = https://typo3.slack.com/messages/C14EQDFL1
 
 # URL of online discussions, you can leave this blank
 project_discussions  =

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -12,7 +12,7 @@ project     = Yoast SEO for TYPO3
 # ...   (recommended) version, displayed next to title (desktop) and in <meta name="book-version"
 # .................................................................................
 
-release     = latest
+release     = 5.0.1
 
 # .................................................................................
 # ...  (recommended) displayed in footer

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -95,7 +95,11 @@ if (!\YoastSeoForTypo3\YoastSeo\Utility\YoastUtility::isPremiumInstalled()) {
 
 $llFolder = 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/';
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = [
+$defaultConfiguration = [
+    'allowedDoktypes' => [
+        'page' => 1,
+        'backend_section' => 5
+    ],
     'translations' => [
         'availableLocales' => [
             'bg_BG',
@@ -173,6 +177,11 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = [
         ],
     ]
 ];
+
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array_merge_recursive(
+    $defaultConfiguration,
+    (array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']
+);
 
 // allow social meta fields to be overlaid
 $GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=


### PR DESCRIPTION
The TypoScript config was not loaded at the moment TCA definitions are processed when you visit a page in the frontend. So moving this configuration was the only option. If you set the allowed doktypes via `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']`, it will be loaded on time. 

The old TypoScript configuration is still possible, but will be removed in a next version. The problem won't get solved when setting the allowed doktypes in TypoScript.