### PR TITLE
[TASK] Make all TCA fields of pages excludable

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -64,7 +64,7 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
         ],
         'tx_yoastseo_score_readability' => [
             'label' => '',
-            'exclude' => false,
+            'exclude' => true,
             'config' => [
                 'type' => 'input',
                 'renderType' => 'hiddenField'
@@ -72,7 +72,7 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
         ],
         'tx_yoastseo_score_seo' => [
             'label' => '',
-            'exclude' => false,
+            'exclude' => true,
             'config' => [
                 'type' => 'input',
                 'renderType' => 'hiddenField'
@@ -87,7 +87,7 @@ if (!\YoastSeoForTypo3\YoastSeo\Utility\YoastUtility::isPremiumInstalled()) {
         [
             'tx_yoastseo_focuskeyword_synonyms' => [
                 'label' => $llPrefix . 'synonyms',
-                'exclude' => false,
+                'exclude' => true,
                 'displayCond' => 'FIELD:tx_yoastseo_hide_snippet_preview:REQ:false',
                 'config' => [
                     'type' => 'text',


### PR DESCRIPTION
All fields can now be excluded with user permissions. It is possible now
to exclude the fields that promotes our premium version. Please only
exclude those fields, when you are also excluding the other fields. We can
only continue the work on this plugin when we sell premium versions as
well.

Resolves #291