### PR TITLE
[BUGFIX] Merge EXTCONF and Typoscript settings for allowedDoktypes

### DIFF
--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -38,29 +38,22 @@ class YoastUtility
     {
         $allowedDoktypes = array_values((array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
 
-        if (empty($allowedDoktypes)) {
-            if ($configuration === null) {
-                trigger_error(
-                    'You are using the old TypoScript way of setting the allowed doktypes. Check documentation on how to set the allowed doktypes correctly',
-                    E_USER_DEPRECATED
-                );
+        if ($configuration === null) {
+            $configuration = self::getTypoScriptConfiguration();
+        }
 
-                $configuration = self::getTypoScriptConfiguration();
-            }
-
-            if (is_array($configuration) &&
-                array_key_exists('allowedDoktypes', $configuration) &&
-                is_array($configuration['allowedDoktypes'])
-            ) {
-                foreach ($configuration['allowedDoktypes'] as $doktype) {
-                    if (!in_array($doktype, $allowedDoktypes)) {
-                        $allowedDoktypes[] = (int)$doktype;
-                    }
+        if (is_array($configuration) &&
+            array_key_exists('allowedDoktypes', $configuration) &&
+            is_array($configuration['allowedDoktypes'])
+        ) {
+            foreach ($configuration['allowedDoktypes'] as $doktype) {
+                if (!in_array($doktype, $allowedDoktypes)) {
+                    $allowedDoktypes[] = (int)$doktype;
                 }
             }
-
-            $allowedDoktypes = $allowedDoktypes ?: [1];
         }
+
+        $allowedDoktypes = $allowedDoktypes ?: [1];
 
         if ($returnInString) {
             return implode(',', $allowedDoktypes);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The EXTCONF and Typoscript settings are now merged, to make sure both ways work (for now)

## Relevant technical choices:

* I removed the deprecation error/notice because the $allowedDoktypes is never empty. 

## Test instructions

This PR can be tested by following these steps:

* Set custom allowed doktypes in EXTCONF and Typoscript and see if they both work.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #298 
