### PR TITLE
[BUGFIX] Cast the pageType to int within the checkRouteEnhancers to support both int and string routing configuration (#288)

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -384,7 +384,7 @@ class PageLayoutHeader
                 if ($routeEnhancer['type'] === 'PageType') {
                     $typeEnhancer = true;
                     foreach ($routeEnhancer['map'] as $pageType) {
-                        if ($pageType === self::FE_PREVIEW_TYPE) {
+                        if ((int)$pageType === self::FE_PREVIEW_TYPE) {
                             $yoastTypeEnhancer = true;
                         }
                     }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The page types within the routing configuration can be set as int and as string, since we apply a strict comparison the casting to integer is needed.

## Relevant technical choices:

* Casting to int on $pageType

## Test instructions

This PR can be tested by following these steps:

* Set the pagetype routing configuration as a string and see if it still works.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #288 
