### PR TITLE
[BUGFIX] Strip javascript tags from rendered body

### DIFF
--- a/Classes/UserFunctions/SnippetPreview.php
+++ b/Classes/UserFunctions/SnippetPreview.php
@@ -80,6 +80,7 @@ class SnippetPreview
             if (is_array($indexableContents[0]) && !empty($indexableContents[0])) {
                 $body = implode($indexableContents[0], '');
             }
+            $body = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $body);
         }
 
         if ($titleFound) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Javascript gets shown in the snippet preview if the javascript is placed after the beginning of the <body> tag. This PR strips out all javascript tags.

## Relevant technical choices:

* Stripped out all javascript tags with a preg_replace

## Test instructions

This PR can be tested by following these steps:

* Place javascript right in the beginning of the body tag (beware, this bug is only visible if you have no TYPO3SEARCH markers within your body). Then check if the snippet preview shows the javascript, apply this patch and check if the javascript is gone.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended