### PR TITLE
[BUGFIX] Restored canonical field for CMS8 and added update script to migrate to canonical core field

### DIFF
--- a/Classes/Install/CanonicalFieldUpdate.php
+++ b/Classes/Install/CanonicalFieldUpdate.php
@@ -1,0 +1,144 @@
+<?php
+namespace YoastSeoForTypo3\YoastSeo\Install;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+/**
+ * Class CanonicalFieldUpdate
+ * @package YoastSeoForTypo3\YoastSeo\Install
+ */
+class CanonicalFieldUpdate extends AbstractUpdate
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier(): string
+    {
+        return 'canonicalFieldUpdate';
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return 'Yoast SEO for TYPO3: Canonical field';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Migrate data from canonical_url to canonical_link in pages (and overlay) table';
+    }
+
+    /**
+     * @param array $databaseQueries
+     * @param string $customMessage
+     * @return bool
+     */
+    public function performUpdate(array &$databaseQueries, &$customMessage): bool
+    {
+        foreach (['pages', 'pages_language_overlay'] as $tableName) {
+            if ($this->checkForMigration($tableName)) {
+                $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($tableName);
+                $qb->getRestrictions()->removeAll();
+
+                $rows = $qb->select('*')
+                    ->from($tableName)
+                    ->where(
+                        $qb->expr()->andX(
+                            $qb->expr()->orX(
+                                $qb->expr()->isNotNull('canonical_url'),
+                                $qb->expr()->neq('canonical_url', $qb->createNamedParameter(''))
+                            ),
+                            $qb->expr()->eq('canonical_link', $qb->createNamedParameter(''))
+                        )
+                    )
+                    ->execute()
+                    ->fetchAll();
+
+                foreach ($rows as $row) {
+                    $qb = GeneralUtility::makeInstance(ConnectionPool::class)
+                        ->getQueryBuilderForTable($tableName);
+                    $qb->update($tableName)
+                        ->set('canonical_link', $qb->createNamedParameter($row['canonical_url']), false)
+                        ->where(
+                            $qb->expr()->eq('uid', $qb->createNamedParameter($row['uid'], Connection::PARAM_INT))
+                        );
+                    $databaseQueries[] = $qb->getSQL();
+                    $qb->execute();
+                }
+            }
+        }
+        $this->markWizardAsDone();
+
+        return true;
+    }
+
+    /**
+     * @param string $description
+     * @return bool
+     */
+    public function checkForUpdate(&$description): bool
+    {
+        if ($this->isWizardDone()) {
+            return false;
+        }
+
+        if ($this->checkForMigration('pages') === false
+            && $this->checkForMigration('pages_language_overlay') === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check for migration
+     *
+     * @param $tableName
+     * @return bool
+     */
+    protected function checkForMigration($tableName): bool
+    {
+        $qb = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($tableName);
+        $qb->getRestrictions()->removeAll();
+
+        try {
+            $qb->select('*')
+                ->from($tableName)
+                ->where(
+                    $qb->expr()->andX(
+                        $qb->expr()->orX(
+                            $qb->expr()->isNotNull('canonical_url'),
+                            $qb->expr()->neq('canonical_url', $qb->createNamedParameter(''))
+                        ),
+                        $qb->expr()->eq('canonical_link', $qb->createNamedParameter(''))
+                    )
+                );
+            return (bool)$qb->execute()->rowCount();
+        } catch (InvalidFieldNameException $e) {
+            // Not needed to update when the old column doesn't exist
+            return false;
+        }
+    }
+}

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -336,6 +336,32 @@ if (version_compare(TYPO3_branch, '9.5', '<')) {
                     $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
                 )
             ],
+            'canonical_link' => [
+                'label' => $llPrefix . 'canonical',
+                'exclude' => true,
+                'config' => [
+                    'type' => 'input',
+                    'size' => 50,
+                    'max' => 1024,
+                    'eval' => 'trim',
+                    'wizards' => [
+                        'link' => [
+                            'type' => 'popup',
+                            'title' => $llPrefix . 'canonical',
+                            'icon' => 'actions-wizard-link',
+                            'module' => [
+                                'name' => 'wizard_link',
+                            ],
+                            'params' => [
+                                'blindLinkOptions' => 'file, folder, mail, spec',
+                                'blindLinkFields' => '',
+                            ],
+                            'JSopenParams' => 'height=300,width=500,status=0,menubar=0,scrollbars=1'
+                        ]
+                    ],
+                    'softref' => 'typolink'
+                ]
+            ],
         ]
     );
 
@@ -369,6 +395,14 @@ if (version_compare(TYPO3_branch, '9.5', '<')) {
         'yoast-robot',
         '
             no_index;' . $llPrefix . 'pages.no_index_formlabel, no_follow;' . $llPrefix . 'pages.no_follow_formlabel,
+        '
+    );
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
+        'pages',
+        'yoast-advanced',
+        '
+        --linebreak--, canonical_link
         '
     );
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -201,6 +201,8 @@ $iconRegistry->registerIcon(
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['seoTitleUpdate']
     = \YoastSeoForTypo3\YoastSeo\Install\SeoTitleUpdate::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['canonicalFieldUpdate']
+    = \YoastSeoForTypo3\YoastSeo\Install\CanonicalFieldUpdate::class;
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('
     config.structuredData.providers {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With version 5.0, the `canonical_url` field was removed to make room for the core field `canonical_link`. For CMS8, this was not added to the TCA and there was no migration script, this has been added now.

## Relevant technical choices:

* Added new update script to migrate the old canonical field for both `pages` and `pages_language_overlay`

## Test instructions

This PR can be tested by following these steps:

* Install in CMS8 installation with the old field still available in the database. Perform upgrade wizard script and take a look in the page properties to see if the field is available at the bottom of the "Yoast SEO" tab.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #312 
