### PR TITLE
[BUGFIX] Use site router to generate uri in order to avoid errors where no base uri has "/" as entry point

### DIFF
--- a/Classes/Frontend/UsePageCache.php
+++ b/Classes/Frontend/UsePageCache.php
@@ -17,7 +17,7 @@ class UsePageCache
      */
     public function usePageCache($pObj, $usePageCache): bool
     {
-        if (YoastRequestHash::isValid($GLOBALS['TYPO3_REQUEST']->getServerParams())) {
+        if (YoastRequestHash::isValid($GLOBALS['TYPO3_REQUEST'])) {
             return false;
         }
         return $usePageCache;

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -25,10 +25,18 @@ class PageRequestMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (YoastRequestHash::isValid($request->getServerParams())) {
+        if (YoastRequestHash::isValid($request)) {
             $context = GeneralUtility::makeInstance(Context::class);
             $context->setAspect('visibility', new VisibilityAspect(true));
+
+            if (isset($request->getServerParams()['HTTP_ORIGIN'])) {
+                $response = $handler->handle($request);
+                $response = $response->withHeader('Access-Control-Allow-Origin', $request->getServerParams()['HTTP_ORIGIN']);
+
+                return $response;
+            }
         }
+
         return $handler->handle($request);
     }
 }

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -67,7 +67,7 @@ class UrlService
                         (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams)
                     );
 
-                    $uri = '/?type=' . self::FE_PREVIEW_TYPE . '&uriToCheck=' . urlencode($uriToCheck);
+                    $uri = (string) $site->getRouter()->generateUri($site->getRootPageId(), ['type' => self::FE_PREVIEW_TYPE, 'uriToCheck' => $uriToCheck]);
                 } else {
                     $uri = BackendUtility::getPreviewUrl($finalPageIdToShow, '', $rootLine, '', '', $additionalGetVars);
                 }

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -67,7 +67,14 @@ class UrlService
                         (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams)
                     );
 
-                    $uri = (string) $site->getRouter()->generateUri($site->getRootPageId(), ['type' => self::FE_PREVIEW_TYPE, 'uriToCheck' => $uriToCheck]);
+                    $uri = (string) $site->getRouter()->generateUri(
+                        $site->getRootPageId(),
+                        [
+                            'type' => self::FE_PREVIEW_TYPE,
+                            'uriToCheck' => $uriToCheck,
+                            'xYoastPageRequest' => GeneralUtility::hmac($uriToCheck)
+                        ]
+                    );
                 } else {
                     $uri = BackendUtility::getPreviewUrl($finalPageIdToShow, '', $rootLine, '', '', $additionalGetVars);
                 }

--- a/Classes/Utility/YoastRequestHash.php
+++ b/Classes/Utility/YoastRequestHash.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace YoastSeoForTypo3\YoastSeo\Utility;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -14,11 +15,21 @@ class YoastRequestHash
      * @param $serverParams
      * @return bool
      */
-    public static function isValid($serverParams): bool
+    public static function isValid(ServerRequestInterface $request): bool
     {
-        return isset($serverParams['HTTP_X_YOAST_PAGE_REQUEST'])
-            && $serverParams['HTTP_X_YOAST_PAGE_REQUEST'] === GeneralUtility::hmac(
-                GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')
-            );
+        $serverParams = $request->getServerParams();
+        $queryParams = $request->getQueryParams();
+
+        if (isset($serverParams['HTTP_X_YOAST_PAGE_REQUEST'])) {
+            $requestUrl = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+
+            return $serverParams['HTTP_X_YOAST_PAGE_REQUEST'] === GeneralUtility::hmac($requestUrl);
+        }
+
+        if (isset($queryParams['xYoastPageRequest']) && isset($queryParams['uriToCheck'])) {
+            return $queryParams['xYoastPageRequest'] === GeneralUtility::hmac($queryParams['uriToCheck']);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [BUGFIX] Use site router to generate uri in order to avoid errors where no base uri has "/" as entry point

## Relevant technical choices:

Use the site router to generate the uri because it makes sure the base uri settings are respected. Without this change `/?type=1234&uriToCheck=xy` might get redirect to `/de` (without the GET parameters), circumventing the special YOAST page type.
With the introduced change the generated uri will look like this: `/de?type=1234&uriToCheck=xy`

## Test instructions

This PR can be tested by following these steps:

* Setup a page with a base uri different from "/" and try to get a plugin preview. (Maybe there have to be two languages with a base uri different from "/")

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #302
