### PR TITLE
[BUGFIX] Fixes favicon parsing not working if there are additional attributes after href

### DIFF
--- a/Classes/UserFunctions/SnippetPreview.php
+++ b/Classes/UserFunctions/SnippetPreview.php
@@ -98,7 +98,7 @@ class SnippetPreview
         $baseUrl = preg_replace('/' . preg_quote($GLOBALS['TSFE']->page['slug'], '/') . '$/', '', $url);
 
         $faviconSrc = $baseUrl . '/favicon.ico';
-        $favIconFound = preg_match('/<link rel=\"shortcut icon\" href=\"(.*)\"/i', $content, $matchesFavIcon);
+        $favIconFound = preg_match('/<link rel=\"shortcut icon\" href=\"([^"]*)\"/i', $content, $matchesFavIcon);
         if ($favIconFound) {
             $faviconSrc = $matchesFavIcon[1];
         }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [BUGFIX] Fixes favicon parsing not working if there are additional attributes after href

## Relevant technical choices:

* Do match anything except `"` character using `[^"]`, instead of matching anything using `.`

## Test instructions

This PR can be tested by following these steps:

* Previous behaviour: https://regex101.com/r/XTtm2T/1/
* New behaviour: https://regex101.com/r/76230x/1/

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
