### PR TITLE
[TASK] Feature flag for allowing doktypes with typoscript setting

### DIFF
--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -38,7 +38,7 @@ class YoastUtility
     {
         $allowedDoktypes = array_values((array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
 
-        if ($configuration === null) {
+        if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowDoktypesFromTypoScript'] && $configuration === null) {
             $configuration = self::getTypoScriptConfiguration();
         }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -99,6 +99,7 @@ $defaultConfiguration = [
         'page' => 1,
         'backend_section' => 5
     ],
+    'allowDoktypesFromTypoScript' => true,
     'translations' => [
         'availableLocales' => [
             'bg_BG',
@@ -177,10 +178,12 @@ $defaultConfiguration = [
     ]
 ];
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array_merge_recursive(
+\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
     $defaultConfiguration,
     (array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']
 );
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = $defaultConfiguration;
+unset($defaultConfiguration);
 
 // allow social meta fields to be overlaid
 $GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=


### PR DESCRIPTION
Makes it possible to disable fetching the setting allowedDoktypes
from typoscript.

Also fixes usage of array_merge_recursive which results in
incorrect merged configuration arrays.

Resolves: #327
