### PR TITLE
[TASK] Add return true to executeUpdate function in CanonicalFieldUpdate.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Besides the free version of our plugin, we also have a premium version. The free
 ## Unreleased
 ### Fixed
 * Removed include of empty TypoScript file which caused errors in TypoScript Object Manager when installed in non-composer-mode. 
+* Add missing return true to executeUpdate function in CanonicalFieldUpdate.php.
 
 ## 6.0.1 April 22, 2020
 ### Fixed

--- a/Classes/Install/CanonicalFieldUpdate.php
+++ b/Classes/Install/CanonicalFieldUpdate.php
@@ -104,6 +104,8 @@ class CanonicalFieldUpdate implements UpgradeWizardInterface
                 }
             }
         }
+
+        return true;
     }
 
     public function updateNecessary(): bool


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Add return true to executeUpdate function in Classes/Install/CanonicalFieldUpdate.php

## Test instructions

This PR can be tested by following these steps:

* Run the CanonicalFieldUpdate Update Wizard from CMS8 to 9 of 10

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #337

