### PR TITLE
[BUGFIX] Fixed the checkForMigration query within the Canonical update script

### DIFF
--- a/Classes/Install/CMS8/CanonicalFieldUpdate.php
+++ b/Classes/Install/CMS8/CanonicalFieldUpdate.php
@@ -124,7 +124,7 @@ class CanonicalFieldUpdate extends AbstractUpdate
         $qb->getRestrictions()->removeAll();
 
         try {
-            $qb->select('*')
+            $qb->count('uid')
                 ->from($tableName)
                 ->where(
                     $qb->expr()->andX(
@@ -135,7 +135,7 @@ class CanonicalFieldUpdate extends AbstractUpdate
                         $qb->expr()->eq('canonical_link', $qb->createNamedParameter(''))
                     )
                 );
-            return (bool)$qb->execute()->rowCount();
+            return (bool)$qb->execute()->fetchColumn();
         } catch (InvalidFieldNameException $e) {
             // Not needed to update when the old column doesn't exist
             return false;

--- a/Classes/Install/CanonicalFieldUpdate.php
+++ b/Classes/Install/CanonicalFieldUpdate.php
@@ -50,7 +50,7 @@ class CanonicalFieldUpdate implements UpgradeWizardInterface
         $qb->getRestrictions()->removeAll();
 
         try {
-            $qb->select('*')
+            $qb->count('uid')
                 ->from($tableName)
                 ->where(
                     $qb->expr()->andX(
@@ -61,7 +61,7 @@ class CanonicalFieldUpdate implements UpgradeWizardInterface
                         $qb->expr()->eq('canonical_link', $qb->createNamedParameter(''))
                     )
                 );
-            return (bool)$qb->execute()->rowCount();
+            return (bool)$qb->execute()->fetchColumn();
         } catch (TableNotFoundException $e) {
             // Not needed to update when the table doesn't exist
             return false;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The query used to determine if the canonical field migration is necessary, gives performance issues with larger database. The query has been altered to fix this.

## Relevant technical choices:

* Instead of the `select('*')` and the `->rowCount()`, the functions `count('uid')` and `->fetchColumn()` are now being used

## Test instructions

This PR can be tested by following these steps:

* Open the upgrade wizard list in the install tool and see if it still shows up (if you have a database which needs migration)

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended