### PR TITLE
[BUGFIX] Remove script and noscript tags and remove some unneccessary whitespaces

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,6 +14,7 @@ additional_hostnames:
 additional_fqdns: []
 provider: default
 use_dns_when_possible: true
+nfs_mount_enabled: true
 omit_containers:
     - dba
 extra_services:


### PR DESCRIPTION
With this change the body text will be cleaned up. `<script>` and `<noscript>` tags will be removed together with the content of the tags. Besides that some whitespaces will be removed.

Resolves: #344 
