### PR TITLE
[!!!][BUGFIX] Removed deprecated functionality to set allowedDoktypes by TypoScript

### DIFF
--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -37,10 +37,6 @@ class YoastUtility
     {
         $allowedDoktypes = array_values((array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']);
 
-        if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowDoktypesFromTypoScript'] && $configuration === null) {
-            $configuration = self::getTypoScriptConfiguration();
-        }
-
         if (is_array($configuration) &&
             array_key_exists('allowedDoktypes', $configuration) &&
             is_array($configuration['allowedDoktypes'])

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -98,7 +98,6 @@ $defaultConfiguration = [
         'page' => 1,
         'backend_section' => 5
     ],
-    'allowDoktypesFromTypoScript' => true,
     'translations' => [
         'availableLocales' => [
             'bg_BG',


### PR DESCRIPTION
By this change, no database action is needed anymore while building the TCA and will prevent issues when updating database schemas on empty databases.

## Summary

This PR can be summarized in the following changelog entry:

* Removed deprecated functionality to provide allowed doktypes in TypoScript. You should configure the doktypes that you want to analyse by setting $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']. See the docs for more information.

## Test instructions

This PR can be tested by following these steps:

Before applying the patch: 
* Remove alias field in pages table
* Run db compare
* You will get a failure now

After applying this patch, it will not give an error anymore when a field is missing.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #350 