### PR TITLE
Add closing semicolon for structured data

### DIFF
--- a/Classes/StructuredData/StructuredDataProviderManager.php
+++ b/Classes/StructuredData/StructuredDataProviderManager.php
@@ -80,7 +80,7 @@ class StructuredDataProviderManager implements SingletonInterface
             }
         }
 
-        return '<script type="application/ld+json">' . json_encode($data, JSON_UNESCAPED_SLASHES) . '</script>';
+        return '<script type="application/ld+json">' . json_encode($data, JSON_UNESCAPED_SLASHES) . ';</script>';
     }
 
     /**


### PR DESCRIPTION
Our MATE extension gathers all set javascript and bundles it. Because there is no closing semicolon for structured data, the next 'var' for example is specified as an unexpected token.

## Summary

This PR can be summarized in the following changelog entry:

* Bugfix: add closing semi colon for JSON LD data

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Check frontend if the semi colon has been added

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
