### PR TITLE
[BUGFIX] use buildUriFromModule for version 8

### DIFF
--- a/Classes/ViewHelpers/RecordLinksViewHelper.php
+++ b/Classes/ViewHelpers/RecordLinksViewHelper.php
@@ -32,7 +32,12 @@ class RecordLinksViewHelper extends AbstractViewHelper
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
     {
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        $returnUri = $uriBuilder->buildUriFromRoute($arguments['module'], GeneralUtility::_GET());
+
+        if (version_compare(TYPO3_branch, '8.7', '<=')) {
+            $returnUri = $uriBuilder->buildUriFromModule($arguments['module'], GeneralUtility::_GET());
+        } else {
+            $returnUri = $uriBuilder->buildUriFromRoute($arguments['module'], GeneralUtility::_GET());
+        }
 
         switch ($arguments['command']) {
             case 'edit':


### PR DESCRIPTION
Version 8 does not have the backend modules defined as backend routes. This causes the overview to give an error when there's records present.

Added a version compare to make sure the buildUriFromModule is used in v8 again, as was before.

## Summary

This PR can be summarized in the following changelog entry:

* Fixed record links viewhelper for version 8

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run a v8 installation and make sure there are records to trigger the error on either the Overview or Redirects (in premium) backend modules

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
