### PR TITLE
[TASK] Remove negative margin of score bar

### DIFF
--- a/Resources/Private/SCSS/Yoast.scss
+++ b/Resources/Private/SCSS/Yoast.scss
@@ -27,7 +27,6 @@
 }
 
 .yoast-seo-score-bar {
-	margin-top: -15px;
 	margin-bottom: 15px;
 
 	&--analysis {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* adapt backend css to prevent overlapping of other third party implementations


## Test instructions

This PR can be tested by following these steps:

* install e.g. the latest t3g/blog version with active PageLayoutHeader (active is default) in the BE.
The score bar is overlapping/overlapped due to it's negative margin-top

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes #324
