### PR TITLE
[BUGFIX] Make sure the path to the backend CSS is always available to show a modal

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -97,7 +97,6 @@ class PageLayoutHeader
             $config = [
                 'urls' => [
                     'workerUrl' => $publicResourcesPath . '/JavaScript/dist/worker.js',
-                    'backendCss' => $publicResourcesPath . '/CSS/yoast-seo-backend.min.css',
                     'previewUrl' => $this->urlService->getPreviewUrl($pageId, (int)$moduleData['language']),
                     'saveScores' => $this->urlService->getSaveScoresUrl(),
                     'prominentWords' => $this->urlService->getUrlForType(1539541406),

--- a/Resources/Public/JavaScript/yoastModal.js
+++ b/Resources/Public/JavaScript/yoastModal.js
@@ -8,7 +8,7 @@ define(['jquery', 'TYPO3/CMS/Backend/Modal'], function ($, Modal) {
     'a.yoast-modal-link { text-decoration: underline; }' +
     'svg.yoast-modal-logo { height: 125px; width: 125px; float: right; margin: 0px 0px 16px 16px; }' +
     '</style>' +
-    '<link rel="stylesheet" type="text/css" href="' + YoastConfig.urls.backendCss + '">';
+    '<link rel="stylesheet" type="text/css" href="' + TYPO3.settings.Yoast.backendCssUrl + '">';
 
   $('*[data-yoast-modal-type="synonyms"]').on('click', function (e) {
     e.preventDefault();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -223,3 +223,12 @@ if (version_compare(TYPO3_branch, '9.5', '<')) {
         }
     }
 '));
+
+if (TYPO3_MODE === 'BE') {
+    $publicResourcesPath =
+        \TYPO3\CMS\Core\Utility\PathUtility::getAbsoluteWebPath(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('yoast_seo')) . 'Resources/Public/';
+
+    /** @var \TYPO3\CMS\Core\Page\PageRenderer $pageRenderer */
+    $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
+    $pageRenderer->addInlineSetting('Yoast', 'backendCssUrl', $publicResourcesPath . 'CSS/yoast-seo-backend.min.css');
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Make sure the path to the backend CSS is always available to show a modal

Fixes #380 
