### PR TITLE
[TASK] Prevent output of empty JSON-LD

### DIFF
--- a/Classes/StructuredData/StructuredDataProviderManager.php
+++ b/Classes/StructuredData/StructuredDataProviderManager.php
@@ -80,6 +80,10 @@ class StructuredDataProviderManager implements SingletonInterface
             }
         }
 
+        if (empty($data)) {
+            return '';
+        }
+
         return '<script type="application/ld+json">' . json_encode($data, JSON_UNESCAPED_SLASHES) . ';</script>';
     }
 


### PR DESCRIPTION
When no structured data is available an empty JSON-LD
is embedded into the HTML source:

<script type="application/ld+json">[]</script>

As this is not necessary the patch removes it.