### PR TITLE
Render cObjects in Sitemap config

### DIFF
--- a/Documentation/OtherPlugins/Sitemap/Index.rst
+++ b/Documentation/OtherPlugins/Sitemap/Index.rst
@@ -38,6 +38,46 @@ you can create as many sitemaps you want. Remember to use unique names. In this 
 
 Within the sitemap configuration you can set some fields:
 
+.. tip::
+
+    It is possible to use cObjects whithin fields.
+
+    .. code-block:: typoscript
+
+        plugin.tx_yoastseo {
+            sitemap {
+                config {
+                    news {
+                        # Use a custom function to find appropriate pid
+                        detailPid = USER
+                        detailPid {
+                            userFunc = My\Custom\Package\UserFunction\NewsUserFunction->findNewsPid
+                            attribute = news_detail_page
+                        }
+
+                        # Different WHERE case depending on current language settings
+                        additionalWhere = CASE
+                        additionalWhere {
+                            key.data = TSFE:sys_language_uid
+
+                            # Default case for sys_language_uid=0
+                            0 = TEXT
+                            0.value = `type` = '0' AND `sys_language_uid` = '0'
+
+                            # Specific case for sys_language_uid > 0
+                            default = TEXT
+                            default {
+                                data = TSFE:sys_language_uid
+                                stdWrap.intval = true
+                                wrap = `type` = '0' AND `uid` IN (SELECT `l10n_parent` FROM `tx_news_domain_model_news` WHERE `sys_language_uid` = '|')
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
 tables
 ~~~~~~
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Detect and render cObjects in TypoScript configuration for Sitemaps

## Relevant technical choices:

* `$sitemapSettings` is passed as reference, and modified only if keys ending with `.` are found
* Parsing happens before the `table` check, meaning it works for both `pages` and custom records alike.

## Test instructions

This PR can be tested by following these steps:

* Add a cObject to an existing sitemap configuration (or a new one). An example for multilingual handling in `news.additionalWhere` was provided in the documentation
* Check sitemap: only matching records should be displayed

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
    * => The `XmlSitemap` is not covered by unit tests at all. Should I add a test 

Fixes #369
