### PR TITLE
[BUGFIX] Fixed reference to setup.typoscript file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is no need for configuration although it is recommended to remove all othe
 This repository uses [the Yoast grunt tasks plugin](https://github.com/Yoast/plugin-grunt-tasks).
 
 ### Changing Frontend behaviour
-As it has always been, you can change frontend behaviour of `yoast_seo` via TypoScript. Check the [current file](Configuration/TypoScript/setup.txt) for reference.
+As it has always been, you can change frontend behaviour of `yoast_seo` via TypoScript. Check the [current file](Configuration/TypoScript/setup.typoscript) for reference.
 
 ## Reporting bugs / Contributions
 Anyone is welcome to contribute to Yoast SEO for TYPO3. Please


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [BUGFIX] Fixed reference to setup.typoscript file

## Relevant technical choices:

* _none_

## Test instructions

This PR can be tested by following these steps:

* _none_

## Quality assurance

* [x] I have clicked the new link in my fork.

Fixes #

In README.md a reference to setup.txt has been replaced to setup.typoscript.