### PR TITLE
[BUGFIX] Fix TYPO3 v9 support

### DIFF
--- a/Classes/Frontend/AdditionalPreviewData.php
+++ b/Classes/Frontend/AdditionalPreviewData.php
@@ -56,7 +56,7 @@ class AdditionalPreviewData implements SingletonInterface
         $request = $GLOBALS['TYPO3_REQUEST'];
         if (class_exists(SiteLanguage::class)) {
             $language = $request->getAttribute('language');
-            if ($language instanceof SiteLanguage && trim($language->getWebsiteTitle())) {
+            if ($language instanceof SiteLanguage && method_exists($language, 'getWebsiteTitle') && trim($language->getWebsiteTitle())) {
                 return trim($language->getWebsiteTitle());
             }
         }


### PR DESCRIPTION
Fix issue #392 by checking if `SiteLanguage::getWebsiteTitle()` exists before calling it

## Summary

This PR can be summarized in the following changelog entry:

* [BUGFIX] Fix TYPO3 v9 support



## Test instructions

This PR can be tested by following these steps:

* Install the extension in TYPO3 v9

## Quality assurance

* [x] I have tested this code
* [ ] I have added unittests to verify the code works as intended

Fixes #392
