### PR TITLE
[FEATURE] Added global configuration for basic auth and disabling preview

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -30,8 +30,6 @@ class PageLayoutHeader
             'languageKeyToLocaleMapping' => []
         ],
         'menuActions' => [],
-        'previewDomain' => null,
-        'previewUrlTemplate' => '',
         'viewSettings' => []
     ];
 
@@ -145,6 +143,11 @@ class PageLayoutHeader
     {
         if (!$GLOBALS['BE_USER'] instanceof BackendUserAuthentication ||
             !$GLOBALS['BE_USER']->check('non_exclude_fields', 'pages:tx_yoastseo_snippetpreview')) {
+            return false;
+        }
+
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview']) &&
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview'] === true) {
             return false;
         }
 

--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -3,7 +3,6 @@ namespace YoastSeoForTypo3\YoastSeo\Backend;
 
 use TYPO3\CMS\Backend\Controller\PageLayoutController;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -74,12 +73,8 @@ class PageLayoutHeader
     {
         $moduleData = BackendUtility::getModuleData(['language'], [], 'web_layout');
         $pageId = (int)GeneralUtility::_GET('id');
-
-        if (!$this->showSnippetPreview()) {
-            return '';
-        }
-
         $currentPage = $this->getCurrentPage($pageId, $moduleData);
+
         if (!YoastUtility::snippetPreviewEnabled($pageId, $currentPage)) {
             return '';
         }
@@ -132,29 +127,6 @@ class PageLayoutHeader
             return $this->getReturnHtml();
         }
         return '';
-    }
-
-    /**
-     * Check to see if snippet preview has to be shown
-     *
-     * @return bool
-     */
-    protected function showSnippetPreview(): bool
-    {
-        if (!$GLOBALS['BE_USER'] instanceof BackendUserAuthentication ||
-            !$GLOBALS['BE_USER']->check('non_exclude_fields', 'pages:tx_yoastseo_snippetpreview')) {
-            return false;
-        }
-
-        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview']) &&
-            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview'] === true) {
-            return false;
-        }
-
-        if ((bool)$GLOBALS['BE_USER']->uc['hideYoastInPageModule']) {
-            return false;
-        }
-        return true;
     }
 
     /**

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -50,8 +50,6 @@ class ModuleController extends ActionController
             'languageKeyToLocaleMapping' => []
         ],
         'menuActions' => [],
-        'previewDomain' => null,
-        'previewUrlTemplate' => '',
         'viewSettings' => []
     ];
 

--- a/Classes/Service/PreviewService.php
+++ b/Classes/Service/PreviewService.php
@@ -65,7 +65,7 @@ class PreviewService
      */
     protected function getContentFromUrl($uriToCheck): string
     {
-        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] = false;
+        $this->setHttpOptions();
         $report = [];
         $content = GeneralUtility::getUrl(
             $uriToCheck,
@@ -191,5 +191,28 @@ class PreviewService
         }
 
         return $text;
+    }
+
+    /**
+     * Set http options for the preview request
+     */
+    protected function setHttpOptions()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify'] = false;
+        if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth'])) {
+            return;
+        }
+
+        $basicAuth = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth'];
+        if (!is_array($basicAuth) || !isset($basicAuth['username'], $basicAuth['password'])) {
+            return;
+        }
+
+        if (!empty($basicAuth['username']) && !empty($basicAuth['password'])) {
+            $GLOBALS['TYPO3_CONF_VARS']['HTTP']['auth'] = [
+                $basicAuth['username'],
+                $basicAuth['password']
+            ];
+        }
     }
 }

--- a/Classes/Service/PreviewService.php
+++ b/Classes/Service/PreviewService.php
@@ -65,6 +65,7 @@ class PreviewService
      */
     protected function getContentFromUrl($uriToCheck): string
     {
+        $backupSettings = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
         $this->setHttpOptions();
         $report = [];
         $content = GeneralUtility::getUrl(
@@ -78,6 +79,7 @@ class PreviewService
             $report
         );
 
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = $backupSettings;
         if ((int)$report['error'] === 0) {
             return $content;
         }

--- a/Documentation/Configuration/SnippetPreview/Index.rst
+++ b/Documentation/Configuration/SnippetPreview/Index.rst
@@ -38,14 +38,6 @@ also disable the snippet preview based on PageTs. Below an example to hide page 
         }
     [global]
 
-Disable snippet preview globally
---------------------------------
-If you want to disable the snippet preview completely, for example for a specific environment, it's possible to set this through :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview']`
-
-.. code-block:: php
-
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview'] = true;
-
 Basic auth configuration
 ------------------------
 For environments which are protected by Basic auth, it's possible to set username and password through :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth']`

--- a/Documentation/Configuration/SnippetPreview/Index.rst
+++ b/Documentation/Configuration/SnippetPreview/Index.rst
@@ -37,3 +37,22 @@ also disable the snippet preview based on PageTs. Below an example to hide page 
             disableSnippetPreview = 1
         }
     [global]
+
+Disable snippet preview globally
+--------------------------------
+If you want to disable the snippet preview completely, for example for a specific environment, it's possible to set this through :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview']`
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview'] = true;
+
+Basic auth configuration
+------------------------
+For environments which are protected by Basic auth, it's possible to set username and password through :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth']`
+
+.. code-block:: php
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth'] = [
+        'username' => 'authUsername',
+        'password' => 'authPassword'
+    ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -156,7 +156,6 @@ $defaultConfiguration = [
         'showAdvancedTab' => true
     ],
     'previewSettings' => [
-        'disablePreview' => false,
         'basicAuth' => [
             'username' => '',
             'password' => '',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -155,7 +155,13 @@ $defaultConfiguration = [
         'showSocialTab' => true,
         'showAdvancedTab' => true
     ],
-    'previewUrlTemplate' => '/?id=%d&type=%d&L=%d',
+    'previewSettings' => [
+        'disablePreview' => false,
+        'basicAuth' => [
+            'username' => '',
+            'password' => '',
+        ]
+    ],
     'overview_filters' => [
         '10' => [
             'key' => 'cornerstone',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Basic auth can now be configured, this will be sent with the preview-request
* Disabling the preview is now also possible through global configuration
* Removed old preview configuration (not used anymore)

## Relevant technical choices:

* Expanded the `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']` with a new `previewSettings` array

## Test instructions

This PR can be tested by following these steps:

* Set `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['disablePreview'] = true` to check if the preview disappears in the backend
* If you want to test the basic auth with the ddev setup:
  * Change the v8 apache configuration within .ddev/apache/apache-site.conf to:
	```
	<Directory "/var/www/html/v8/">
		AllowOverride All
		Allow from All
		AuthType Basic
		AuthName "Restricted Content"
		AuthUserFile /etc/apache2/.htpasswd
		Require valid-user
	</Directory>
	```
  * SSH into the container (`ddev ssh`) and set the contents of `/etc/apache2/.htpasswd` to:
    * `yoast:$2a$13$MU5T.Rhhr83gV6v4hkhYNuOVYLI3lz6ta0oq5aZPDq.nKyK/uNBnq`
  * Login in the backend https://v8.yoast-seo.ddev.site/ with yoast / basicauth
  * When you select a page you should see that the preview shows a 401 error
  * Set the configuration of basic auth:
    * `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['previewSettings']['basicAuth'] = ['username' => 'yoast', 'password' => 'basicauth'];`
  * Clear caches and check if the preview works

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #171  #243