### PR TITLE
[TASK] Updated sitemap documentation with a warning to only use in TYPO3 8.7

### DIFF
--- a/Documentation/Configuration/Sitemap/Index.rst
+++ b/Documentation/Configuration/Sitemap/Index.rst
@@ -11,6 +11,13 @@
 XML Sitemap
 ===========
 
+.. warning::
+    You should only use the sitemap functionality if you have a TYPO3 8.7 installation.
+
+    If you have TYPO3 9.5 or higher, the sitemap functionality is shipped with core in EXT:seo:
+
+    https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/XmlSitemap/Index.html
+
 From version 3.0 of EXT:yoast_seo, we ship a extendable sitemap functionality. It is enabled by default and showing all
 normal pages. But there are some configuration options.
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Added a warning to the sitemap documentation to only use the functionality in TYPO3 8.7, added a link to the official TYPO3 documentation for the sitemap shipped with EXT:seo

## Relevant technical choices:

* Added empty lines between the sentences to force a newline.
* The version of the documentation is still on 5.1.0 but this will be fixed with the newest release

## Test instructions

This PR can be tested by following these steps:

* Run `ddev docs` and see if the warning is showed correctly

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #399
