### PR TITLE
[BUGFIX] Fixed the baseUrl assignment within PreviewService, which also fixes the default favicon call

### DIFF
--- a/Classes/Service/PreviewService.php
+++ b/Classes/Service/PreviewService.php
@@ -132,8 +132,9 @@ class PreviewService
         if ($localeFound) {
             $locale = trim($matchesLocale[1]);
         }
-        $url = preg_replace('/\/$/', '', $uriToCheck);
-        $baseUrl = preg_replace('/' . preg_quote('/', '/') . '$/', '', $url);
+        $urlParts = parse_url(preg_replace('/\/$/', '', $uriToCheck));
+        $baseUrl = $urlParts['scheme'] . '://' . $urlParts['host'];
+        $url = $baseUrl . $urlParts['path'];
 
         $faviconSrc = $baseUrl . '/favicon.ico';
         $favIconFound = preg_match('/<link rel=\"shortcut icon\" href=\"([^"]*)\"/i', $content, $matchesFavIcon);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The baseUrl variable was not set correctly, which also meant that the default favicon (/favicon.ico) could not be found on a subpage.

## Relevant technical choices:

* The uriToCheck is now passed through the parse_url function from which the `$baseUrl` and `$url` variable are set

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Check if all previews still work
* Check if the favicon (if you have one) is now present on a subpage

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #296 
