### PR TITLE
Add checks for TYPO3 v11 in CI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         typo3: ['8', '9', '10']
         php: ['php7.2', 'php7.3', 'php7.4']
         experimental: [false]
-      include:
-        - typo3: '11'
-          php: 'php7.4'
-          experimental: true
+        include:
+          - typo3: '11'
+            php: 'php7.4'
+            experimental: true
     steps:
       - uses: actions/checkout@v1
       - name: Set up PHP Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         php: ['php7.2', 'php7.3', 'php7.4']
         experimental: [false]
       include:
-        typo3: '11'
-        php: 'php7.4'
-        experimental: true
+        - typo3: '11'
+          php: 'php7.4'
+          experimental: true
     steps:
       - uses: actions/checkout@v1
       - name: Set up PHP Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,18 @@ jobs:
   build-php:
     name: Build PHP
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       max-parallel: 6
       fail-fast: false
       matrix:
         typo3: ['8', '9', '10']
         php: ['php7.2', 'php7.3', 'php7.4']
+        experimental: [false]
+      include:
+        typo3: '11'
+        php: 'php7.4'
+        experimental: true
     steps:
       - uses: actions/checkout@v1
       - name: Set up PHP Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           composer --version
       - name: Install
         run: |
-          composer require typo3/cms-core:^${{ matrix.typo3 }} --no-progress
+          composer require typo3/cms-core:^${{ matrix.typo3 }} typo3/cms-backend:^${{ matrix.typo3 }} typo3/cms-extbase:^${{ matrix.typo3 }} typo3/cms-fluid:^${{ matrix.typo3 }} typo3/cms-frontend:^${{ matrix.typo3 }} typo3/cms-install:^${{ matrix.typo3 }} --no-progress
           git checkout composer.json
       - name: Lint
         run: composer test:php:lint

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,10 @@
     "friendsofphp/php-cs-fixer": "^2.0",
     "overtrue/phplint": "^2.0",
     "phpstan/phpstan": "^0.12.32",
-    "typo3/tailor": "^1.1"
+    "phpstan/extension-installer": "^1.0",
+    "slam/phpstan-extensions": "^5.0",
+    "typo3/tailor": "^1.1",
+    "saschaegerer/phpstan-typo3": "dev-master"
   },
   "replace": {
     "typo3-ter/yoast-seo": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,6 @@
     "friendsofphp/php-cs-fixer": "^2.0",
     "overtrue/phplint": "^2.0",
     "phpstan/phpstan": "^0.12.32",
-    "phpstan/extension-installer": "^1.0",
-    "saschaegerer/phpstan-typo3": "^0.13.1",
-    "slam/phpstan-extensions": "^5.0",
     "typo3/tailor": "^1.1"
   },
   "replace": {

--- a/phpstan.cms11.neon
+++ b/phpstan.cms11.neon
@@ -1,0 +1,14 @@
+parameters:
+  level: 0
+  paths:
+    - Classes
+    - Configuration
+  ignoreErrors:
+    -
+      message: '#Call to an undefined static method TYPO3\\CMS\\Backend\\Utility\\BackendUtility::getModuleUrl\(\)#'
+      path: Classes/Controller/OverviewController.php
+  excludes_analyse:
+    - Classes/Install/CMS8
+    - Classes/UserFunctions/XmlSitemap.php
+    - Classes/UserFunctions/SnippetPreview.php
+    - Classes/Utility/CanonicalizationUtility.php


### PR DESCRIPTION
## Summary

Added some checks for TYPO3 v11 to the CI process to have an overview if the code is "ready" for TYPO3 v11. This might help getting the extension ready to work with TYPO3 v11. This check might fail and will not prevent any release etc.
