### PR TITLE
[BUGFIX] fixes ajax text analysis returning empty body

### DIFF
--- a/Classes/Service/PreviewService.php
+++ b/Classes/Service/PreviewService.php
@@ -105,7 +105,7 @@ class PreviewService
             $content,
             $matchesDescription
         );
-        $bodyFound = preg_match("/<body[^>]*>(.*?)<\/body>/is", $content, $matchesBody);
+        $bodyFound = preg_match("/<body[^>]*>(.*)<\/body>/is", $content, $matchesBody);
 
         if ($bodyFound) {
             $body = $matchesBody[1];


### PR DESCRIPTION
## Summary

In some cases the ajax request ?route=/ajaxyoast/preview/ results in an empty body in the json response.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended