### PR TITLE
[BUGFIX] Fix issues with CI on older PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-php:
     name: Build PHP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       max-parallel: 6


### PR DESCRIPTION
The CI was using ubuntu-latest which had only PHP 7.4 - 8.0 support. Switching back to Ubuntu 18 to make sure we can test against older PHP versions as well.