### PR TITLE
[SECURITY] Move preview url generating to AjaxController, preventing passing complete url as parameter

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -4,11 +4,16 @@ namespace YoastSeoForTypo3\YoastSeo\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
 use YoastSeoForTypo3\YoastSeo\Service\PreviewService;
+use YoastSeoForTypo3\YoastSeo\Utility\YoastUtility;
 
 /**
  * Class AjaxController
@@ -26,9 +31,17 @@ class AjaxController
     ): ResponseInterface {
         $queryParams = $request->getQueryParams();
 
+        if (!isset($queryParams['pageId'], $queryParams['languageId'], $queryParams['additionalGetVars'])) {
+            return new JsonResponse();
+        }
+
         $previewService = GeneralUtility::makeInstance(PreviewService::class);
         $content = $previewService->getPreviewData(
-            $queryParams['uriToCheck'],
+            $this->getUriToCheck(
+                (int)$queryParams['pageId'],
+                (int)$queryParams['languageId'],
+                (string)$queryParams['additionalGetVars']
+            ),
             (int)$queryParams['pageId']
         );
 
@@ -56,6 +69,58 @@ class AjaxController
 
         $response->getBody()->write(json_encode(['OK']));
         return $response;
+    }
+
+    /**
+     * @param int    $pageId
+     * @param int    $languageId
+     * @param string $additionalGetVars
+     * @return string
+     */
+    protected function getUriToCheck(int $pageId, int $languageId, string $additionalGetVars): string
+    {
+        if (!empty($additionalGetVars)) {
+            $additionalGetVars = urldecode($additionalGetVars);
+        }
+
+        $rootLine = BackendUtility::BEgetRootLine($pageId);
+        // Mount point overlay: Set new target page id and mp parameter
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $finalPageIdToShow = $pageId;
+        $mountPointInformation = $pageRepository->getMountPointInfo($pageId);
+        if ($mountPointInformation && $mountPointInformation['overlay']) {
+            // New page id
+            $finalPageIdToShow = $mountPointInformation['mount_pid'];
+            $additionalGetVars .= '&MP=' . $mountPointInformation['MPvar'];
+        }
+
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        try {
+            $site = $siteFinder->getSiteByPageId($finalPageIdToShow, $rootLine);
+        } catch (SiteNotFoundException $e) {
+            return '';
+        }
+
+        $additionalQueryParams = [];
+        parse_str($additionalGetVars, $additionalQueryParams);
+        $additionalQueryParams['_language'] = $site->getLanguageById($languageId);
+        $uriToCheck = YoastUtility::fixAbsoluteUrl(
+            (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams)
+        );
+
+        if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'])) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'] as $_funcRef) {
+                $_params = [
+                    'urlToCheck' => $uriToCheck,
+                    'site' => $site,
+                    'finalPageIdToShow' => $finalPageIdToShow,
+                    'languageId' => $languageId
+                ];
+
+                $uriToCheck = GeneralUtility::callUserFunction($_funcRef, $_params, $this);
+            }
+        }
+        return (string)$uriToCheck;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Instead of generating the preview-url and passing through the complete URL as `uriToCheck`, the needed parameters are being send and generating is done within AjaxController

## Relevant technical choices:

* Url generation is moved, with some small optimizations for `SiteNotFoundException` and removal of `BackendUtility::getPreviewUrl`

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Check if the preview still works in CMS8, CMS9 and CMS10

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [] I have added unittests to verify the code works as intended