### PR TITLE
WIP: [FEATURE] Add TYPO3 v11 support

### DIFF
--- a/.ddev/apache/apache-site.conf
+++ b/.ddev/apache/apache-site.conf
@@ -128,6 +128,25 @@ ServerName yoast-seo.ddev.site
     ServerAlias v10.yoast-seo.ddev.site
 
     <Directory "/var/www/html/v10/">
+        AllowOverride All
+        Allow from All
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+</VirtualHost>
+
+<VirtualHost *:80>
+    RewriteEngine On
+    RewriteCond %{HTTP:X-Forwarded-Proto} =https
+    RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
+    RewriteRule    ^(.+[^/])$           https://%{HTTP_HOST}$1/ [redirect,last]
+
+    DocumentRoot /var/www/html/v11/public
+    ServerAlias v11.yoast-seo.ddev.site
+
+    <Directory "/var/www/html/v11/">
   		AllowOverride All
   		Allow from All
 	</Directory>

--- a/.ddev/commands/web/install-all
+++ b/.ddev/commands/web/install-all
@@ -5,3 +5,4 @@ ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_
 $ABSOLUTE_PATH/install-v10
 $ABSOLUTE_PATH/install-v9
 $ABSOLUTE_PATH/install-v8
+$ABSOLUTE_PATH/install-v11

--- a/.ddev/commands/web/install-v11
+++ b/.ddev/commands/web/install-v11
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+VERSION=v11
+
+rm -rf /var/www/html/$VERSION/*
+echo "{}" > /var/www/html/$VERSION/composer.json
+composer config extra.typo3/cms.web-dir public -d /var/www/html/$VERSION
+composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/www/html/$VERSION
+composer req t3/cms:'^11' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
+
+
+cd /var/www/html/$VERSION
+
+TYPO3_INSTALL_DB_DBNAME=$VERSION
+vendor/bin/typo3cms install:setup -n --database-name $VERSION
+vendor/bin/typo3cms configuration:set 'BE/debug' 1
+vendor/bin/typo3cms configuration:set 'FE/debug' 1
+vendor/bin/typo3cms configuration:set 'SYS/devIPmask' '*'
+vendor/bin/typo3cms configuration:set 'SYS/displayErrors' 1
+vendor/bin/typo3cms configuration:set 'SYS/trustedHostsPattern' '.*.*'
+vendor/bin/typo3cms configuration:set 'MAIL/transport' 'smtp'
+vendor/bin/typo3cms configuration:set 'MAIL/transport_smtp_server' 'localhost:1025'
+vendor/bin/typo3cms configuration:set 'GFX/processor' 'ImageMagick'
+vendor/bin/typo3cms configuration:set 'GFX/processor_path' '/usr/bin/'
+vendor/bin/typo3cms configuration:set 'GFX/processor_path_lzw' '/usr/bin/'
+vendor/bin/typo3cms install:generatepackagestates
+
+sed -i -e "s/base: ht\//base: \//g" /var/www/html/$VERSION/config/sites/main/config.yaml
+sed -i -e 's/base: \/en\//base: \//g' /var/www/html/$VERSION/config/sites/main/config.yaml
+
+vendor/bin/typo3cms cache:flush

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -2,7 +2,7 @@ name: yoast-seo
 type: php
 docroot: ~
 no_project_mount: true
-php_version: "7.2"
+php_version: "7.4"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -11,6 +11,7 @@ additional_hostnames:
     - v8.yoast-seo
     - v9.yoast-seo
     - v10.yoast-seo
+    - v11.yoast-seo
 additional_fqdns: []
 provider: default
 use_dns_when_possible: true
@@ -21,3 +22,4 @@ extra_services:
     - v8-data
     - v9-data
     - v10-data
+    - v11-data

--- a/.ddev/docker-compose.web.yaml
+++ b/.ddev/docker-compose.web.yaml
@@ -25,6 +25,7 @@ services:
             - v8-data:/var/www/html/v8
             - v9-data:/var/www/html/v9
             - v10-data:/var/www/html/v10
+            - v11-data:/var/www/html/v11
 volumes:
     v8-data:
         name: "${DDEV_SITENAME}-v8-data"
@@ -32,3 +33,5 @@ volumes:
         name: "${DDEV_SITENAME}-v9-data"
     v10-data:
         name: "${DDEV_SITENAME}-v10-data"
+    v11-data:
+        name: "${DDEV_SITENAME}-v11-data"

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -9,6 +9,7 @@ RUN echo "<body><h1>EXT:${EXTENSION_KEY} Dev Environments</h1><ul>" >> /var/www/
 RUN echo "<li><h2>TYPO3 8.7 LTS</h2><a href="https://v8.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v8.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
 RUN echo "<li><h2>TYPO3 9.5 LTS</h2><a href="https://v9.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v9.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
 RUN echo "<li><h2>TYPO3 10.4 LTS</h2><a href="https://v10.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v10.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
+RUN echo "<li><h2>TYPO3 11.x</h2><a href="https://v11.${DDEV_SITENAME}.ddev.site/">Frontend</a> | <a href="https://v11.${DDEV_SITENAME}.ddev.site/typo3/">Backend</a></li>" >> /var/www/html/index.html
 RUN echo "</ul>" >> /var/www/html/index.html
 RUN echo "<hr>" >> /var/www/html/index.html
 RUN echo "<h3>TYPO3 Backend</h3><ul><li><b>User:</b> <code>admin</code></li><li><b>Password:</b> <code>password</code> (also Install Tool)</li></ul>" >> /var/www/html/index.html
@@ -24,6 +25,9 @@ RUN echo "<h1>Perform this first</h1> <code>ddev install-v9</code>" > /var/www/h
 RUN mkdir -p /var/www/html/v10/public/typo3
 RUN echo "<h1>Perform this first</h1> <code>ddev install-v10</code>" > /var/www/html/v10/public/index.html
 RUN echo "<h1>Perform this first</h1> <code>ddev install-v10</code>" > /var/www/html/v10/public/typo3/index.html
+RUN mkdir -p /var/www/html/v11/public/typo3
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v11</code>" > /var/www/html/v11/public/index.html
+RUN echo "<h1>Perform this first</h1> <code>ddev install-v11</code>" > /var/www/html/v11/public/typo3/index.html
 
 ARG uid
 ARG gid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         typo3: ['8', '9', '10']
-        php: ['php7.2', 'php7.3', 'php7.4']
+        php: ['php7.4']
         experimental: [false]
         include:
           - typo3: '11'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The following instances will be up and running for you after you have installed 
 
 - https://v8.yoast-seo.ddev.site
 - https://v9.yoast-seo.ddev.site
-- https://v10.yoast-seo.ddev.site 
+- https://v10.yoast-seo.ddev.site
+- https://v11.yoast-seo.ddev.site
 
 #### Login
 You will be able to login to the backend of the instances above, by using the following credentials:
@@ -68,7 +69,7 @@ ddev rm -O -R
 ```
 and after that:
 ```bash
-docker volume rm yoast-seo-v8-data yoast-seo-v9-data yoast-seo-v10-data
+docker volume rm yoast-seo-v8-data yoast-seo-v9-data yoast-seo-v10-data yoast-seo-v11-data
 ```
 
 If you change the code, you can directly see the changes in all the installations of your DDEV setup.

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
   ],
   "homepage": "https://yoast.com",
   "require": {
-    "typo3/cms-core": "^8.7|^9.5|^10.3",
-    "typo3/cms-backend": "^8.7|^9.5|^10.3",
-    "typo3/cms-extbase": "^8.7|^9.5|^10.3",
-    "typo3/cms-fluid": "^8.7|^9.5|^10.3",
-    "typo3/cms-frontend": "^8.7|^9.5|^10.3",
-    "typo3/cms-install": "^8.7|^9.5|^10.3",
+    "typo3/cms-core": "^8.7|^9.5|^10.3|^11",
+    "typo3/cms-backend": "^8.7|^9.5|^10.3|^11",
+    "typo3/cms-extbase": "^8.7|^9.5|^10.3|^11",
+    "typo3/cms-fluid": "^8.7|^9.5|^10.3|^11",
+    "typo3/cms-frontend": "^8.7|^9.5|^10.3|^11",
+    "typo3/cms-install": "^8.7|^9.5|^10.3|^11",
     "ext-curl": "*",
     "ext-json": "*",
-    "php": "^7.0"
+    "php": "^7.4"
   },
   "suggest": {
     "typo3/cms-seo": "^9.5|^10.3"

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,8 @@
 <?php
 
 if (TYPO3_MODE === 'BE') {
+    $isV11 = version_compare(TYPO3_version, '11.0.0', '>=');
+
     $offset = 0;
     foreach ($GLOBALS['TBE_MODULES'] as $key => $_) {
         if ($key == 'web') {
@@ -17,13 +19,14 @@ if (TYPO3_MODE === 'BE') {
         'name' => 'yoast'
     ];
 
+    $controller = !$isV11 ? 'Module' : \YoastSeoForTypo3\YoastSeo\Controller\ModuleController::class;
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
         'YoastSeoForTypo3.yoast_seo',
         'yoast',
         'dashboard',
         '',
         [
-            'Module' => 'dashboard',
+            $controller => 'dashboard',
         ],
         [
             'access' => 'user,group',
@@ -32,13 +35,14 @@ if (TYPO3_MODE === 'BE') {
         ]
     );
 
+    $controller = !$isV11 ? 'Overview' : \YoastSeoForTypo3\YoastSeo\Controller\OverviewController::class;
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
         'YoastSeoForTypo3.yoast_seo',
         'yoast',
         'overview',
         '',
         [
-            'Overview' => 'list',
+            $controller => 'list',
         ],
         [
             'access' => 'user,group',
@@ -47,13 +51,14 @@ if (TYPO3_MODE === 'BE') {
         ]
     );
 
+    $controller = !$isV11 ? 'Module' : \YoastSeoForTypo3\YoastSeo\Controller\ModuleController::class;
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
         'YoastSeoForTypo3.yoast_seo',
         'yoast',
         'premium',
         '',
         [
-            'Module' => 'premium',
+            $controller => 'premium',
         ],
         [
             'access' => 'user,group',


### PR DESCRIPTION
This adds support for TYPO3 v11 which is currently being developed. It does not work yet completely and following issues I have noticed:

> Argument 2 passed to YoastSeoForTypo3\YoastSeo\Utility\YoastUtility::snippetPreviewEnabled() must be of the type array, null given, called in /var/www/yoast_seo/Classes/Backend/PageLayoutHeader.php on line 78

This happens upon opening the Page module (and selecting a page).

> Fluid parse error in template Overview_action_list_8a2de03de095304698a1a0b4272cc9491c607f05, line 46 at character 7. Error: The ViewHelper "<f:widget.paginate>" could not be resolved. Based on your spelling, the system would load the class "TYPO3Fluid\Fluid\ViewHelpers\Widget\PaginateViewHelper", however this class does not exist. (error code 1407060572). Template source chunk: <f:widget.paginate objects="{items}" as="paginatedItems" configuration="{itemsPerPage: settings.itemsPerPage, insertAbove: 1, insertBelow: 1, maximumNumberOfLinks: 6}">

This happens upon opening the Overview module. Other BE modules by Yoast SEO (Dashboard; Premium) appear to work.

As the PHP needs to be raised - [see roadmap](https://typo3.org/cms/roadmap) - question will have to be answered whether this should lead to a different branch, PHP 7.2/7.3 will be dropped only or a different solution is desired.

I will continue to work in this as soon as I have time but wanted to share my current status in case others want to proceed in the meantime and to get my question answered. Of course comments & feedback is welcomed too ;)

## Summary

This PR can be summarized in the following changelog entry:

* Add TYPO3 v11 support
* Raise PHP dependency to 7.4

## Relevant technical choices:

* PHP dep raised to 7.4

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
