### PR TITLE
Preview snippet language fallback for "All [-1]"

### DIFF
--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -311,7 +311,7 @@ class SnippetPreview extends AbstractNode
                     $previewPageId = $recordArray[$l18nPointer];
                 }
             }
-            $languageId = $recordArray[$languageField];
+            $languageId = $recordArray[$languageField] > -1 ? $recordArray[$languageField] : 0;
         }
 
         // map record data to GET parameters


### PR DESCRIPTION
If for example a news record has set sys_language_uid to value -1 (all languages flag), you won't be able to edit this record anymore.

When yoast_seo/Classes/Service/UrlService.php:75 call TYPO3\CMS\Core\Site\Entity\Site->getLanguageById(-1) it will throw an exception: "Language -1 does not exist on site [SITENAME]."
