### PR TITLE
[CLEANUP] Remove unnecessary DB columns

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,7 +9,7 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
             'exclude' => true,
             'displayCond' => 'FIELD:tx_yoastseo_hide_snippet_preview:REQ:false',
             'config' => [
-                'type' => 'text',
+                'type' => 'none',
                 'renderType' => 'snippetPreview',
                 'settings' => [
                     'titleField' => 'seo_title',
@@ -22,7 +22,7 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
             'exclude' => true,
             'displayCond' => 'FIELD:tx_yoastseo_hide_snippet_preview:REQ:false',
             'config' => [
-                'type' => 'text',
+                'type' => 'none',
                 'renderType' => 'readabilityAnalysis'
             ]
         ],
@@ -46,7 +46,7 @@ $llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
             'exclude' => true,
             'displayCond' => 'FIELD:tx_yoastseo_hide_snippet_preview:REQ:false',
             'config' => [
-                'type' => 'input',
+                'type' => 'none',
                 'renderType' => 'focusKeywordAnalysis',
                 'settings' => [
                     'focusKeywordField' => 'tx_yoastseo_focuskeyword',

--- a/Documentation/Configuration/OtherPlugins/Index.rst
+++ b/Documentation/Configuration/OtherPlugins/Index.rst
@@ -27,7 +27,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'exclude' => true,
                 'displayCond' => 'REC:NEW:false',
                 'config' => [
-                    'type' => 'text',
+                    'type' => 'none',
                     'renderType' => 'snippetPreview',
                     'settings' => [
                         'titleField' => 'alternative_title',
@@ -39,7 +39,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'label' => $llPrefix . 'analysis',
                 'exclude' => true,
                 'config' => [
-                    'type' => 'text',
+                    'type' => 'none',
                     'renderType' => 'readabilityAnalysis'
                 ]
             ],
@@ -54,7 +54,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'label' => $llPrefix . 'analysis',
                 'exclude' => true,
                 'config' => [
-                    'type' => 'input',
+                    'type' => 'none',
                     'renderType' => 'focusKeywordAnalysis',
                     'settings' => [
                         'focusKeywordField' => 'tx_yoastseo_focuskeyword',

--- a/Documentation/OtherPlugins/Analysis/Index.rst
+++ b/Documentation/OtherPlugins/Analysis/Index.rst
@@ -27,7 +27,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'exclude' => true,
                 'displayCond' => 'REC:NEW:false',
                 'config' => [
-                    'type' => 'text',
+                    'type' => 'none',
                     'renderType' => 'snippetPreview',
                     'settings' => [
                         'titleField' => 'alternative_title',
@@ -39,7 +39,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'label' => $llPrefix . 'analysis',
                 'exclude' => true,
                 'config' => [
-                    'type' => 'text',
+                    'type' => 'none',
                     'renderType' => 'readabilityAnalysis'
                 ]
             ],
@@ -54,7 +54,7 @@ SEO analysis is only done on pages. If you want more type of records to use the 
                 'label' => $llPrefix . 'analysis',
                 'exclude' => true,
                 'config' => [
-                    'type' => 'input',
+                    'type' => 'none',
                     'renderType' => 'focusKeywordAnalysis',
                     'settings' => [
                         'focusKeywordField' => 'tx_yoastseo_focuskeyword',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -172,7 +172,6 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=
     ',canonical_url'
     . ',og_title'
     . ',og_description'
-    . ',tx_yoastseo_robot_instructions'
     . ',seo_title'
     . ',twitter_title'
     . ',twitter_description';

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -4,7 +4,6 @@
 CREATE TABLE pages (
 	tx_yoastseo_focuskeyword tinytext,
 	tx_yoastseo_focuskeyword_synonyms tinytext,
-	tx_yoastseo_robot_instructions int(11) DEFAULT '0' NOT NULL,
 	tx_yoastseo_hide_snippet_preview tinyint(3) DEFAULT '0' NOT NULL,
 	tx_yoastseo_cornerstone tinyint(3) DEFAULT '0' NOT NULL,
 	tx_yoastseo_score_readability varchar(50) DEFAULT '' NOT NULL,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -8,9 +8,6 @@ CREATE TABLE pages (
 	tx_yoastseo_cornerstone tinyint(3) DEFAULT '0' NOT NULL,
 	tx_yoastseo_score_readability varchar(50) DEFAULT '' NOT NULL,
 	tx_yoastseo_score_seo varchar(50) DEFAULT '' NOT NULL,
-	tx_yoastseo_snippetpreview tinyint(3) DEFAULT '0' NOT NULL,
-	tx_yoastseo_focuskeyword_analysis tinyint(3) DEFAULT '0' NOT NULL,
-	tx_yoastseo_readability_analysis tinyint(3) DEFAULT '0' NOT NULL,
 	tx_yoastseo_focuskeyword_premium int(11) DEFAULT '0' NOT NULL,
 	KEY tx_yoastseo_cornerstone (tx_yoastseo_cornerstone),
 );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Remove DB columns for virtual fields
* Remove legacy `tx_yoastseo_robot_instructions` column definition

## Relevant technical choices:

I couldn't find any place in the current codebase where data was written in one of those following DB fields:
* `tx_yoastseo_robot_instructions`
* `tx_yoastseo_snippetpreview`
* `tx_yoastseo_focuskeyword_analysis`
* `tx_yoastseo_readability_analysis`

AFAIK they could/should be removed.

## Test instructions

This PR can be tested by following these steps:

* Remove the fields using `./vendor/bin/typo3cms database:updateschema destructive`
* The columns will be prefixed, but everything will keep working:
    * Snippet preview
    * Overview
    * Sitemaps

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
