### PR TITLE
[BUGFIX] Render twitter:card in page.meta within CMS8.typoscript

### DIFF
--- a/Configuration/TypoScript/Setup/CMS8.typoscript
+++ b/Configuration/TypoScript/Setup/CMS8.typoscript
@@ -229,6 +229,7 @@ page.meta {
     og:image.cObject < lib.yoastSEO.og.images
     og:image.attribute = property
     twitter:title.cObject < lib.yoastSEO.twitter.title
+    twitter:card.cObject < lib.yoastSEO.twitter.card
     twitter:description.cObject < lib.yoastSEO.twitter.description
     twitter:image.cObject < lib.yoastSEO.twitter.images
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* `twitter:card` (summary) was not being loaded for CMS8

## Relevant technical choices:

* Used the same method as the rest of the page meta headers

## Test instructions

This PR can be tested by following these steps:

* Check if the meta tag `twitter:card` is visible in the source with the value `summary`

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #434
