### PR TITLE
[BUGFIX] urlToCheck hook now accepts both AjaxController and UrlService as class (regression)

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 use YoastSeoForTypo3\YoastSeo\Service\PreviewService;
+use YoastSeoForTypo3\YoastSeo\Service\UrlService;
 use YoastSeoForTypo3\YoastSeo\Utility\YoastUtility;
 
 /**
@@ -108,8 +109,12 @@ class AjaxController
             (string)$site->getRouter()->generateUri($finalPageIdToShow, $additionalQueryParams)
         );
 
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'])) {
-            foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'] as $_funcRef) {
+        $urlToCheckHook = $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck']
+            ?? $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][UrlService::class]['urlToCheck']
+            ?? [];
+
+        if (is_array($urlToCheckHook)) {
+            foreach ($urlToCheckHook as $_funcRef) {
                 $_params = [
                     'urlToCheck' => $uriToCheck,
                     'site' => $site,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With the latest security fix, the url generation was moved to `AjaxController`. Unfortunately `self::class` was not changed for the `urlToCheck` hook which meant that hooks registered to `UrlService` were not working anymore
* Because it's possible that users have already changed this hook, both `AjaxController` and `UrlService` are valid now.

## Relevant technical choices:

* First the `AjaxController` hooks are checked with a fallback to `UrlService`

## Test instructions

This PR can be tested by following these steps:

* Add the hook with the steps in the documentation: https://docs.typo3.org/p/yoast-seo-for-typo3/yoast_seo/master/en-us/Configuration/Hooks/Index.html
* Try registering with both `AjaxController` and `UrlService` and see if the hook still works

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #441