### PR TITLE
added additionalGetVars for TYPO3_branch < 9.5

### DIFF
--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -54,7 +54,7 @@ class UrlService
                 'pageId' => $pageId, 'languageId' => $languageId, 'additionalGetVars' => urlencode($additionalGetVars)
             ]);
         }
-        return $this->getUrlForType(self::FE_PREVIEW_TYPE, '&pageIdToCheck=' . $pageId . '&languageIdToCheck=' . $languageId);
+        return $this->getUrlForType(self::FE_PREVIEW_TYPE, '&pageIdToCheck=' . $pageId . '&languageIdToCheck=' . $languageId . '&additionalGetVars=' . urlencode($additionalGetVars));
     }
 
     /**


### PR DESCRIPTION
Fixes #

This fixes YoastSeoForTypo3\YoastSeo\UserFunctions\SnippetPreview,
the render() function has this line:

 $additionalGetVars = urldecode(GeneralUtility::_GET('additionalGetVars'));

And for TYPO3 with version less than 9.5 you are not passing the additionalGetVars,
so the SnippetPreview fails to work with my custom "news" record, which needs a "news" GET param..

Resolves #443 , resolves #266
