### PR TITLE
fixes issues with CanonicalGenerator.php

### DIFF
--- a/Classes/Canonical/CanonicalGenerator.php
+++ b/Classes/Canonical/CanonicalGenerator.php
@@ -39,6 +39,17 @@ class CanonicalGenerator
     {
         if ($typoScriptFrontendController === null) {
             $typoScriptFrontendController = $this->getTypoScriptFrontendController();
+
+            if (empty($typoScriptFrontendController->page)) {
+                $typoScriptFrontendController->getPageAndRootLine();
+            }
+
+            if (!is_object($this->typoScriptFrontendController->cObj)) {
+                $typoScriptFrontendController->initTemplate();
+                $typoScriptFrontendController->getConfigArray();
+                $typoScriptFrontendController->settingLanguage();
+                $typoScriptFrontendController->newCObj();
+            }
         }
         if ($signalSlotDispatcher === null) {
             $signalSlotDispatcher = GeneralUtility::makeInstance(Dispatcher::class);

--- a/Classes/Canonical/CanonicalGenerator.php
+++ b/Classes/Canonical/CanonicalGenerator.php
@@ -40,15 +40,17 @@ class CanonicalGenerator
         if ($typoScriptFrontendController === null) {
             $typoScriptFrontendController = $this->getTypoScriptFrontendController();
 
-            if (empty($typoScriptFrontendController->page)) {
-                $typoScriptFrontendController->getPageAndRootLine();
-            }
+            if (!is_null($typoScriptFrontendController)) {
+                if (empty($typoScriptFrontendController->page)) {
+                    $typoScriptFrontendController->getPageAndRootLine();
+                }
 
-            if (!is_object($this->typoScriptFrontendController->cObj)) {
-                $typoScriptFrontendController->initTemplate();
-                $typoScriptFrontendController->getConfigArray();
-                $typoScriptFrontendController->settingLanguage();
-                $typoScriptFrontendController->newCObj();
+                if (!is_object($this->typoScriptFrontendController->cObj)) {
+                    $typoScriptFrontendController->initTemplate();
+                    $typoScriptFrontendController->getConfigArray();
+                    $typoScriptFrontendController->settingLanguage();
+                    $typoScriptFrontendController->newCObj();
+                }
             }
         }
         if ($signalSlotDispatcher === null) {


### PR DESCRIPTION
Fixes #
fixes issues when calling typoscriptFrontEndController->page['.. and also  typoscriptFrontEndController->cObj
in this file at least.

Some people were also complaining here:
https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/213
that "page" came empty, and got an error when calling page['no_index ...

This fixes it also.