### PR TITLE
[BUGFIX] for issue #448: fix failure in loading femanager module

### DIFF
--- a/Classes/Canonical/CanonicalGenerator.php
+++ b/Classes/Canonical/CanonicalGenerator.php
@@ -129,21 +129,25 @@ class CanonicalGenerator
      */
     protected function checkDefaultCanonical(): string
     {
-        return $this->typoScriptFrontendController->cObj->typoLink_URL([
-            'parameter' => $this->typoScriptFrontendController->id . ',' . $this->typoScriptFrontendController->type,
-            'forceAbsoluteUrl' => true,
-            'addQueryString' => true,
-            'addQueryString.' => [
-                'method' => 'GET',
-                'exclude' => implode(
-                    ',',
-                    CanonicalizationUtility::getParamsToExcludeForCanonicalizedUrl(
-                        (int)$this->typoScriptFrontendController->id,
-                        (array)$GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
-                    )
-                )
-            ]
-        ]);
+        if (!empty($this->typoScriptFrontendController->cObj)) {
+            return $this->typoScriptFrontendController->cObj->typoLink_URL([
+                'parameter' => $this->typoScriptFrontendController->id . ',' . $this->typoScriptFrontendController->type,
+                'forceAbsoluteUrl' => true,
+                'addQueryString' => true,
+                'addQueryString.' => [
+                    'method' => 'GET',
+                    'exclude' => implode(
+                        ',',
+                        CanonicalizationUtility::getParamsToExcludeForCanonicalizedUrl(
+                            (int)$this->typoScriptFrontendController->id,
+                            (array)$GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
+                            )
+                            )
+                        ]
+                    ]);
+        } else {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
## Changes
* add condition to check if $this->typoScriptFrontendController->cObj is null

## Summary

This PR can be summarized in the following changelog entry:

* fix failure in loading femanager module

## Relevant technical choices:

* return empty string if $this->typoScriptFrontendController->cObj is null

## Test instructions

This PR can be tested by following these steps:

* open femanager module in BE

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #448

## Technical info

    TYPO3 version: 8.7.32
    Yoast SEO version: 7.2.4 (7.0.6)
    femanager version: 5.5.1 (5.4.1)