### PR TITLE
Corrected JSON-LD output to be valid

### DIFF
--- a/Classes/StructuredData/StructuredDataProviderManager.php
+++ b/Classes/StructuredData/StructuredDataProviderManager.php
@@ -84,7 +84,7 @@ class StructuredDataProviderManager implements SingletonInterface
             return '';
         }
 
-        return '<script type="application/ld+json">' . json_encode($data) . ';</script>';
+        return '<script type="application/ld+json">' . json_encode($data) . '</script>';
     }
 
     /**


### PR DESCRIPTION
Fixed  StructuredDataProviderManager::buildJsonLdBlob() and removed tailing `;` from JSON-LD to build a valid JSON string.

## Summary
The generated JSON is not valid and could produce an error when it is analysed by e. g. an Facebook Pixel Code that is included on the website.
Also see https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/412

## Test instructions

This PR can be tested by following these steps:

* Generate a website with enabled Yoast Extension where a bread crumb or any other JSON-LD output from Yoast can be found in the pages source code.
* Place the following FB Pixel in the template
```html
<script>
	!function(f,b,e,v,n,t,s)
	{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
	n.callMethod.apply(n,arguments):n.queue.push(arguments)};
	if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
	n.queue=[];t=b.createElement(e);t.async=!0;
	t.src=v;s=b.getElementsByTagName(e)[0];
	s.parentNode.insertBefore(t,s)}(window, document,'script',
	'https://connect.facebook.net/en_US/fbevents.js');
	fbq('init', 'YOUR_PIXEL_ID');
	fbq('track', 'PageView');
</script>
```
* Open the website and have a look into the consoles output
* Before the patch you'll find an error message `[Facebook Pixel] - Unable to parse JSON-LD tag. Malformed JSON found: '[{...}];'`
* After the patch is applied, the error message disapears.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
