### PR TITLE
[BUGFIX] Use all cached providers data

### DIFF
--- a/Classes/StructuredData/StructuredDataProviderManager.php
+++ b/Classes/StructuredData/StructuredDataProviderManager.php
@@ -110,7 +110,7 @@ class StructuredDataProviderManager implements SingletonInterface
                 if (!empty($data)) {
                     $structuredData[$provider] = $data;
                 }
-                break;
+                continue;
             }
             if (class_exists($configuration['provider'])
                 && is_subclass_of($configuration['provider'], StructuredDataProviderInterface::class)) {


### PR DESCRIPTION
The break did prevent all other providers data to be used.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
