### PR TITLE
Fix wrong type in getPreviewPageId()

### DIFF
--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -358,7 +358,7 @@ class SnippetPreview extends AbstractNode
     protected function getPreviewPageId(int $currentPageId, array $previewConfiguration): int
     {
         // find the right preview page id
-        $previewPageId = $previewConfiguration['previewPageId'] ?? 0;
+        $previewPageId = (int)$previewConfiguration['previewPageId'] ?? 0;
 
         // if no preview page was configured
         if (!$previewPageId) {


### PR DESCRIPTION
This pull request fixes wrong return type in getPreviewPageId().

> TypeError
> Return value of YoastSeoForTypo3\YoastSeo\Form\Element\SnippetPreview::getPreviewPageId() must be of the type int, string returned

https://github.com/Yoast/Yoast-SEO-for-TYPO3/blob/4ae867e486f6dace18f21c83c33f2627313dfb4a/Classes/Form/Element/SnippetPreview.php#L361

If a `previewPageId` (for example `TCEMAIN.preview.tx_news_domain_model_news.previewPageId = 2`) was provided, a string was returned. With this fix, the value is casted to an integer.