### PR TITLE
[TASK] Set saschaegerer/phpstan-typo3 dev-dependency to ^0.13 since slam/phpstan-extensions is not ready for phpstan ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",
     "overtrue/phplint": "^2.0",
-    "phpstan/phpstan": "^0.12.32",
+    "phpstan/phpstan": "^0.12",
     "phpstan/extension-installer": "^1.0",
     "slam/phpstan-extensions": "^5.0",
     "typo3/tailor": "^1.1",
-    "saschaegerer/phpstan-typo3": "dev-master"
+    "saschaegerer/phpstan-typo3": "^0.13"
   },
   "replace": {
     "typo3-ter/yoast-seo": "self.version"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* We had a dependency of `dev-master` on saschaegerer/phpstan-typo3 which failed now because of the dependency on phpstan/phpstan^1.0

## Relevant technical choices:

* Because the `slam/phpstan-extensions` package is not yet available for phpstan^1.0, I've set the dependency of phpstan-typo3 to ^0.13 so the builds will succeed again

## Test instructions

This PR can be tested by following these steps:

* If the github actions from this pull request works, it's successful

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended