### PR TITLE
[FEATURE] Support for PHP 8, fixed warnings and introduced RequestFactory for requesting frontend url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - typo3: '11'
             php: 'php7.4'
             experimental: false
+          - typo3: '11'
+            php: 'php8.0'
+            experimental: false
     steps:
       - uses: actions/checkout@v1
       - name: Set up PHP Version

--- a/Classes/Form/Element/SnippetPreview.php
+++ b/Classes/Form/Element/SnippetPreview.php
@@ -130,7 +130,7 @@ class SnippetPreview extends AbstractNode
             $this->titleField = $this->data['parameterArray']['fieldConf']['config']['settings']['titleField'];
         }
 
-        if (array_key_exists('titleField', (array)$this->data['parameterArray']['fieldConf']['config']['settings']) &&
+        if (array_key_exists('pageTitleField', (array)$this->data['parameterArray']['fieldConf']['config']['settings']) &&
             $this->data['parameterArray']['fieldConf']['config']['settings']['pageTitleField']
         ) {
             $this->pageTitleField = $this->data['parameterArray']['fieldConf']['config']['settings']['pageTitleField'];
@@ -143,10 +143,12 @@ class SnippetPreview extends AbstractNode
                 $this->data['parameterArray']['fieldConf']['config']['settings']['descriptionField'];
         }
 
-        if (array_key_exists('0', (array)$this->data['databaseRow']['sys_language_uid']) &&
-            $this->data['databaseRow']['sys_language_uid'][0]
-        ) {
-            $this->languageId = (int)$this->data['databaseRow']['sys_language_uid'][0];
+        if (isset($this->data['databaseRow']['sys_language_uid'])) {
+            if (is_array($this->data['databaseRow']['sys_language_uid']) && count($this->data['databaseRow']['sys_language_uid']) > 0) {
+                $this->languageId = current($this->data['databaseRow']['sys_language_uid']);
+            } else {
+                $this->languageId = (int)$this->data['databaseRow']['sys_language_uid'];
+            }
         }
 
         $this->table = $this->data['tableName'];

--- a/Classes/Service/UrlService.php
+++ b/Classes/Service/UrlService.php
@@ -68,17 +68,15 @@ class UrlService implements SingletonInterface
                 (string)$this->generateUri($site, $pageId, $languageId, $additionalGetVars)
             );
 
-            if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'])) {
-                foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'] as $_funcRef) {
-                    $_params = [
-                        'urlToCheck' => $uriToCheck,
-                        'site' => $site,
-                        'finalPageIdToShow' => $pageId,
-                        'languageId' => $languageId
-                    ];
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][self::class]['urlToCheck'] ?? [] as $_funcRef) {
+                $_params = [
+                    'urlToCheck' => $uriToCheck,
+                    'site' => $site,
+                    'finalPageIdToShow' => $pageId,
+                    'languageId' => $languageId
+                ];
 
-                    $uriToCheck = GeneralUtility::callUserFunction($_funcRef, $_params, $this);
-                }
+                $uriToCheck = GeneralUtility::callUserFunction($_funcRef, $_params, $this);
             }
             return $uriToCheck;
         }

--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -82,7 +82,7 @@ class YoastUtility
             return false;
         }
 
-        if ((bool)$GLOBALS['BE_USER']->uc['hideYoastInPageModule']) {
+        if ((bool)($GLOBALS['BE_USER']->uc['hideYoastInPageModule'] ?? false)) {
             return false;
         }
 
@@ -123,12 +123,10 @@ class YoastUtility
             'uid' => $uid
         ];
 
-        if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['get_focus_keyword']) {
-            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['get_focus_keyword'] as $_funcRef) {
-                if ($_funcRef) {
-                    $tmp = new \stdClass();
-                    GeneralUtility::callUserFunction($_funcRef, $params, $tmp);
-                }
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['get_focus_keyword'] ?? [] as $_funcRef) {
+            if ($_funcRef) {
+                $tmp = new \stdClass();
+                GeneralUtility::callUserFunction($_funcRef, $params, $tmp);
             }
         }
 
@@ -186,7 +184,7 @@ class YoastUtility
             $configuration = self::getTypoScriptConfiguration();
         }
 
-        return !((int)$_ENV['YOAST_DEVELOPMENT_MODE'] === 1 || (int)$configuration['developmentMode'] === 1);
+        return !((int)($_ENV['YOAST_DEVELOPMENT_MODE'] ?? 0) === 1 || (int)($configuration['developmentMode'] ?? 0) === 1);
     }
 
     protected static function getTypoScriptConfiguration(): array

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "typo3/cms-seo": "^9.5|^10.4|^11.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "php": "^7.2"
+    "php": "^7.2 || ^8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -189,19 +189,10 @@ $defaultConfiguration = [
 
 \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
     $defaultConfiguration,
-    (array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']
+    (array)($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] ?? [])
 );
 $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = $defaultConfiguration;
 unset($defaultConfiguration);
-
-// allow social meta fields to be overlaid
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .=
-    ',canonical_url'
-    . ',og_title'
-    . ',og_description'
-    . ',seo_title'
-    . ',twitter_title'
-    . ',twitter_description';
 
 $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
 $iconRegistry->registerIcon(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduced PHP8 support for Yoast SEO through composer.json
* Added PHPStan check for TYPO311 with PHP8
* Introduced `RequestFactory` to request the frontend url since `GeneralUtility::getUrl` dropped support for adding headers to the call
* Introduced multiple `??` checks to prevent undefined index warnings
* Removed `pageOverlayFields` from ext_localconf, this functionality was already removed since TYPO3 8
* Fixed 2 bugs regarding `pageTitleField` and `sys_language_uid`

## Relevant technical choices:

* The check on `sys_language_uid` within the `SnippetPreview` has been expanded to first check if it is an array, otherwise cast to integer because it's not always an array (anymore)

## Test instructions

This PR can be tested by following these steps:

* Test this branch in a PHP8 environment and see if everything still works and there are no warnings (visible or in the log files)

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #461
