### PR TITLE
Fix type error in PageLayoutHeader class

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -20,7 +20,7 @@ class PageLayoutHeader extends AbstractPageLayoutHeader
         $pageId = $this->getPageId();
         $currentPage = $this->getCurrentPage($pageId, $moduleData, $parentObj);
 
-        if ($this->shouldShowPreview($pageId, $currentPage)) {
+        if (is_array($currentPage) && $this->shouldShowPreview($pageId, $currentPage)) {
             $this->pageHeaderService->setSnippetPreviewEnabled(true);
             $this->pageHeaderService->setModuleData($moduleData);
             $this->pageHeaderService->setPageId($pageId);


### PR DESCRIPTION
## Summary

Error is thrown in page module:

Argument 2 passed to YoastSeoForTypo3\YoastSeo\Backend\AbstractPageLayoutHeader::shouldShowPreview() must be of the type array, null given, called in /var/www/html/public/typo3conf/ext/yoast_seo/Classes/Backend/PageLayoutHeader.php on line 23

## Test instructions

This PR can be tested by following these steps (TYPO3 v11.5.2):

* Go into page module
* Select a page in the page tree
* Select "Language" in the upper menu bar (the second select box)
* Select "All languages" in the upper menu bar (the first select box)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

$this->getCurrentPage() returns null in this case and $this->shouldShowPreview() expects an array as second argument. The patch avoids this type error, no snippet is displayed in this case.
