### PR TITLE
Set branch alias to current version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "6.x-dev"
+      "dev-master": "8.x-dev"
     },
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Correct branch-alias entry in composer.json

## Relevant technical choices:

First, this is the correct branch alias. Second, this prevents a composer dependency error when requiring master branch with installed roave/security-advisories, as EXT:yoast_seo is marked as conflict for versions < 7.2.3.