### PR TITLE
[TASK] Added min-height to snippet preview container to prevent layout shifting

### DIFF
--- a/Resources/Private/SCSS/Yoast.scss
+++ b/Resources/Private/SCSS/Yoast.scss
@@ -113,6 +113,7 @@
 }
 
 .yoast-seo-snippet-preview-styling {
+	min-height: 235px;
 	fieldset {
 		legend {
 			font-size: 12px !important;

--- a/Resources/Public/CSS/yoast.min.css
+++ b/Resources/Public/CSS/yoast.min.css
@@ -75,13 +75,14 @@
   border: 1px solid #cccccc;
   background-color: #FFF; }
 
-.yoast-seo-snippet-preview-styling fieldset legend {
-  font-size: 12px !important;
-  border-bottom: 0 !important; }
-
-.yoast-seo-snippet-preview-styling fieldset label {
-  font-size: 12px !important;
-  font-weight: normal; }
+.yoast-seo-snippet-preview-styling {
+  min-height: 235px; }
+  .yoast-seo-snippet-preview-styling fieldset legend {
+    font-size: 12px !important;
+    border-bottom: 0 !important; }
+  .yoast-seo-snippet-preview-styling fieldset label {
+    font-size: 12px !important;
+    font-weight: normal; }
 
 div.yoast-analysis button {
   background-color: inherit !important;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Prevent layout shifting of the page module caused by the snippet preview

## Relevant technical choices:

* Added `min-height: 235px;` to the `.yoast-seo-snippet-preview-styling` (container div), this should solve most cases. Only when the title is 2 lines there's a small shift

## Test instructions

This PR can be tested by following these steps:

* Check within the page module if the container is now larger and the layout shifting is gone (or atleast minimal)

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #452
