### PR TITLE
Prevent 'undefined array key' warnings with php 8 when extconf 'allowedDoktypes' missing

### DIFF
--- a/Classes/Utility/YoastUtility.php
+++ b/Classes/Utility/YoastUtility.php
@@ -47,7 +47,8 @@ class YoastUtility
         // @phpstan-ignore-next-line
         $allowedDoktypes = array_map(function ($doktype) {
             return (int)$doktype;
-        }, array_values((array)$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes']));
+        }, array_values((array)($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo']['allowedDoktypes'] ?? [])));
+
 
         if (isset($configuration['allowedDoktypes'])
             && is_array($configuration['allowedDoktypes'])


### PR DESCRIPTION
In TYPO11 with PHP 8 there are a `PHP Warning: Undefined array key ...`.
This PR adds a additional check (null coalescing operator's) to prevents this error.