### PR TITLE
[DOCS] Fix incorrect PHP array syntax

### DIFF
--- a/Documentation/Configuration/StructuredData/Index.rst
+++ b/Documentation/Configuration/StructuredData/Index.rst
@@ -107,8 +107,8 @@ It is possible to register a custom provider. For this, it's necessary to create
                 [
                     '@context' => 'https://schema.org',
                     '@type' => 'Person',
-                    'name': 'John Doe',
-                    'email': 'john@doe.com'
+                    'name' => 'John Doe',
+                    'email' => 'john@doe.com'
                 ]
             ];
         }


### PR DESCRIPTION
Example of getData() return value of a StructuredDataProvider contains incorrect PHP syntax

## Summary

This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
