### PR TITLE
[BUGFIX] Fixed deprecated extension name usage within ext_tables.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Besides the free version of our plugin, we also have a premium version. The free
 
 ### Fixed
 - Adjusted analysis calls when there is more than 1 related keyphrase due to bug in "yoastseo" package
+- Deprecated extension name usage within ext_tables.php
 
 ## 8.1.0 November 24, 2021
 ### Added

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -17,16 +17,18 @@ if (TYPO3_MODE === 'BE') {
         'name' => 'yoast'
     ];
 
+    $registerExtension = 'YoastSeo';
     $moduleController = \YoastSeoForTypo3\YoastSeo\Controller\ModuleController::class;
     $overviewController = \YoastSeoForTypo3\YoastSeo\Controller\OverviewController::class;
     if (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class)
             ->getMajorVersion() < 10) {
+        $registerExtension = 'YoastSeoForTypo3.yoast_seo';
         $moduleController = 'Module';
         $overviewController = 'Overview';
     }
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'YoastSeoForTypo3.yoast_seo',
+        $registerExtension,
         'yoast',
         'dashboard',
         '',
@@ -41,7 +43,7 @@ if (TYPO3_MODE === 'BE') {
     );
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'YoastSeoForTypo3.yoast_seo',
+        $registerExtension,
         'yoast',
         'overview',
         '',
@@ -56,7 +58,7 @@ if (TYPO3_MODE === 'BE') {
     );
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'YoastSeoForTypo3.yoast_seo',
+        $registerExtension,
         'yoast',
         'premium',
         '',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html, within ext_tables.php there was still a deprecated usage of extension name

## Relevant technical choices:

* Since we still support CMS9, this was fixed in the same way as the controller calls

## Test instructions

This PR can be tested by following these steps:

* Pull branch and check if the backend modules are still working on CMS9, CMS10 and CMS11

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #474
