### PR TITLE
[BUGFIX] Fixed php8 error within FocusKeywordAnalysis.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Besides the free version of our plugin, we also have a premium version. The free
 
 ### Fixed
 - Adjusted analysis calls when there is more than 1 related keyphrase due to bug in "yoastseo" package
+- PHP8 warning within `FocusKeywordAnalysis.php`
 
 ## 8.1.0 November 24, 2021
 ### Added

--- a/Classes/Form/Element/FocusKeywordAnalysis.php
+++ b/Classes/Form/Element/FocusKeywordAnalysis.php
@@ -40,9 +40,9 @@ class FocusKeywordAnalysis extends AbstractNode
 
         if (array_key_exists(
             'focusKeywordField',
-            (array)$this->data['parameterArray']['fieldConf']['config']['settings']
+            (array)($this->data['parameterArray']['fieldConf']['config']['settings'] ?? [])
         ) &&
-            $this->data['parameterArray']['fieldConf']['config']['settings']['focusKeywordField']
+            !empty($this->data['parameterArray']['fieldConf']['config']['settings']['focusKeywordField'])
         ) {
             $this->focusKeywordField =
                 $this->data['parameterArray']['fieldConf']['config']['settings']['focusKeywordField'];


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* While testing the premium extension with PHP8, an error was found within `FocusKeywordAnalysis.php`

## Relevant technical choices:

* Added extra checks if the `settings` array exists

## Test instructions

This PR can be tested by following these steps:

* Pull the branch and test in CMS9, CMS10 and CMS11

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
