### PR TITLE
[BUGFIX] Fixed Github CI pipelines by adding the correct allow-plugins to composer.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
           composer --version
       - name: Install
         run: |
-          composer config allow-plugins.typo3/cms-composer-installers true
-          composer config allow-plugins.typo3/class-alias-loader true
-          composer config allow-plugins.phpstan/extension-installer true
           composer require typo3/cms-core:^${{ matrix.typo3 }} typo3/cms-backend:^${{ matrix.typo3 }} typo3/cms-extbase:^${{ matrix.typo3 }} typo3/cms-fluid:^${{ matrix.typo3 }} typo3/cms-frontend:^${{ matrix.typo3 }} typo3/cms-install:^${{ matrix.typo3 }} --no-progress
       - name: Lint
         run: composer test:php:lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ We will follow [Semantic Versioning](http://semver.org/).
 ## Yoast SEO Premium for TYPO3
 Besides the free version of our plugin, we also have a premium version. The free version enables you to do all necessary optimizations. With the premium version, we make it even easier to do! More information can be found on https://www.maxserv.com/yoast.
 
+## UNRELEASED
+### Fixed
+- Github CI pipelines by adding the correct "allow-plugins" to composer.json
+
 ## 8.3.0 August 3, 2022
 ### Fixed
 - Lists within the Overview module now take the "DB Mounts" of a user into account

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,12 @@
   },
   "config": {
     "vendor-dir": "vendor",
-    "bin-dir": "vendor/bin"
+    "bin-dir": "vendor/bin",
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true,
+      "phpstan/extension-installer": true
+    }
   },
   "scripts": {
     "test:php:lint": [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Github CI failed because of missing `allow-plugins` within composer.json

## Relevant technical choices:

* Instead of manually setting these in the Github CI yaml files, they're added to the composer.json

## Test instructions

This PR can be tested by following these steps:

* Composer install on the branch, you should not be asked to allow the plugins

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended