### PR TITLE
[BUGFIX] Fixed Content-Security-Policy issues in the backend of TYPO3 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Fixed
+- Content Security Policy issues in CMS12 by adding extra parameter within BackendYoastConfig and removing unnecessary inline code within FocusKeywordAnalysis.html
+
 ## 9.0.0 June 12, 2023
 ### Breaking
 - Dropped support for CMS9

--- a/Classes/Hooks/BackendYoastConfig.php
+++ b/Classes/Hooks/BackendYoastConfig.php
@@ -22,6 +22,6 @@ class BackendYoastConfig
         }
 
         $jsonConfigUtility = GeneralUtility::makeInstance(JsonConfigUtility::class);
-        $pObject->addJsInlineCode('yoast-json-config', $jsonConfigUtility->render());
+        $pObject->addJsInlineCode('yoast-json-config', $jsonConfigUtility->render(), true, false, true);
     }
 }

--- a/Resources/Private/Templates/TCA/FocusKeywordAnalysis.html
+++ b/Resources/Private/Templates/TCA/FocusKeywordAnalysis.html
@@ -6,12 +6,6 @@
 		</div>
 	</f:then>
 	<f:else>
-		<script>
-            var tx_yoast_seo = tx_yoast_seo || {};
-            <f:if condition="{focusKeywordField}">
-            tx_yoast_seo.focusKeywordField = '{focusKeywordField}';
-            </f:if>
-		</script>
 		<f:render partial="Analysis" arguments="{type: 'seo', subtype: subtype}" />
 	</f:else>
 </f:if>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixes `Content-Security-Policy` issues in the backend of TYPO3 12

## Relevant technical choices:

* Added extra argument to `addJsInlineCode` within `BackendYoastConfig.php`
* Removed unnecessary/old inline code within `FocusKeywordAnalysis.html`

## Test instructions

This PR can be tested by following these steps:

* Pull branch, enable the content security policy for the backend in 12 and check if there are no errors now

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #533
