### PR TITLE
[BUGFIX] Caught InvalidArgumentException within BreadcrumbStructuredDataProvider when the current site language does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We will follow [Semantic Versioning](http://semver.org/).
 - Avoid exceptions because of broken showitem tt_content types
 - PHP warnings within several Form classes due to non-existing doktype index within databaseRow array
 - Favicons with relative urls or urls with a port
+- Caught InvalidArgumentException within BreadcrumbStructuredDataProvider when the current site language does not exist
 
 ## 9.0.0 June 12, 2023
 ### Breaking

--- a/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
+++ b/Classes/StructuredData/BreadcrumbStructuredDataProvider.php
@@ -74,12 +74,11 @@ class BreadcrumbStructuredDataProvider implements StructuredDataProviderInterfac
     {
         if (class_exists(SiteFinder::class)) {
             try {
-                $site = $this->siteFinder->getSiteByPageId((int)$pageId);
-            } catch (SiteNotFoundException $e) {
+                $site = $this->siteFinder->getSiteByPageId($pageId);
+                return (string)$site->getRouter()->generateUri($pageId, ['_language' => $this->getLanguage()]);
+            } catch (SiteNotFoundException | \InvalidArgumentException $e) {
                 return '';
             }
-
-            return (string)$site->getRouter()->generateUri($pageId, ['_language' => $this->getLanguage()]);
         }
 
         $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* When the current site language does not exist (probably only in nested sites?), there's a `InvalidArgumentException` being thrown which was not caught.

## Relevant technical choices:

* Moved the `return (string)$site->.....` within the `try` block and added the `InvalidArgumentException` to be caught

## Test instructions

This PR can be tested by following these steps:

* Pull branch and check if the breadcrumb is still being rendered correctly

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #523
