### PR TITLE
[BUGFIX] Show warning on linking suggestions when content element is set to 'All Languages' instead of fatal exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Fixed
+- Show warning on linking suggestions when content element is set to "All Languages" instead of fatal exception
+
 ## 9.0.1 July 6, 2023
 ### Fixed
 - Content Security Policy issues in CMS12 by adding extra parameter within BackendYoastConfig and removing unnecessary inline code within FocusKeywordAnalysis.html

--- a/Classes/Form/Element/InternalLinkingSuggestion.php
+++ b/Classes/Form/Element/InternalLinkingSuggestion.php
@@ -48,6 +48,13 @@ class InternalLinkingSuggestion extends AbstractNode
 
     public function render(): array
     {
+        $locale = $this->getLocale($this->currentPage);
+        if ($locale === null) {
+            $this->templateView->assign('languageError', true);
+            $resultArray['html'] = $this->templateView->render();
+            return $resultArray;
+        }
+
         $publicResourcesPath = PathUtility::getPublicPathToResources();
 
         $resultArray = $this->initializeResultArray();
@@ -67,7 +74,7 @@ class InternalLinkingSuggestion extends AbstractNode
             ],
             'linkingSuggestions' => [
                 'excludedPage' => $this->currentPage,
-                'locale' => $this->getLocale($this->currentPage)
+                'locale' => $locale
             ],
             'urls' => [
                 'workerUrl' => $workerUrl,
@@ -95,10 +102,9 @@ class InternalLinkingSuggestion extends AbstractNode
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
         try {
             $site = $siteFinder->getSiteByPageId($pageId);
-        } catch (SiteNotFoundException $e) {
+            return $site->getLanguageById($this->languageId)->getTwoLetterIsoCode();
+        } catch (SiteNotFoundException|\InvalidArgumentException $e) {
             return null;
         }
-        $siteLanguage = $site->getLanguageById($this->languageId);
-        return $siteLanguage->getTwoLetterIsoCode();
     }
 }

--- a/Resources/Private/Language/BackendModule.xlf
+++ b/Resources/Private/Language/BackendModule.xlf
@@ -193,6 +193,12 @@
 			<trans-unit id="tx_yoastseo_linking_suggestions.intro" resname="tx_yoastseo_linking_suggestions.intro">
 				<source>To improve your site structure, consider linking to other relevant pages or records on your website. In the list below you'll find suggestions, cornerstone content is highlighted with an asterisk (*).</source>
 			</trans-unit>
+			<trans-unit id="tx_yoastseo_linking_suggestions.languageError.title" resname="tx_yoastseo_linking_suggestions.languageError.title">
+				<source>Unable to determine linking suggestions.</source>
+			</trans-unit>
+			<trans-unit id="tx_yoastseo_linking_suggestions.languageError" resname="tx_yoastseo_linking_suggestions.languageError">
+				<source>This content element does not have a language to analyze.</source>
+			</trans-unit>
 
 			<trans-unit id="page" xml:space="preserve">
 				<source>Page</source>

--- a/Resources/Private/Templates/TCA/InternalLinkingSuggestion.html
+++ b/Resources/Private/Templates/TCA/InternalLinkingSuggestion.html
@@ -1,2 +1,28 @@
-<div><p><f:translate key="LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:tx_yoastseo_linking_suggestions.intro" /></p></div>
-<div data-yoast-linking-suggestions />
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:if condition="{languageError}">
+    <f:then>
+        <div class="alert alert-warning">
+            <h5 class="alert-heading alert-title">
+                <f:translate
+                        key="LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:tx_yoastseo_linking_suggestions.languageError.title" />
+            </h5>
+            <div class="alert-body">
+                <f:translate
+                        key="LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:tx_yoastseo_linking_suggestions.languageError" />
+            </div>
+        </div>
+    </f:then>
+    <f:else>
+        <div>
+            <p>
+                <f:translate
+                        key="LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:tx_yoastseo_linking_suggestions.intro" />
+            </p>
+        </div>
+        <div data-yoast-linking-suggestions />
+    </f:else>
+</f:if>
+
+</html>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Internal linking suggestions should show a warning within a content element with Language "All" (-1) instead of throwing an exception

## Relevant technical choices:

* Moved the `getLanguageById(....` call into the `try`/`catch` block to catch the `InvalidArgumentException`, if the `$locale` is `null` the warning is rendered within the template

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Add a content element with Language "All"
* Check if the warning is shown within the Internal Linking Suggestions

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #543 