### PR TITLE
[BUGFIX] Fixe wrong access values in Modules.php

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -12,7 +12,7 @@ return [
     ],
     'yoast_YoastSeoDashboard' => [
         'parent' => 'yoast',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/yoast/dashboard',
         'iconIdentifier' => 'module-yoast-dashboard',
         'labels' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModuleDashboard.xlf',
@@ -23,7 +23,7 @@ return [
     ],
     'yoast_YoastSeoOverview' => [
         'parent' => 'yoast',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/yoast/overview',
         'iconIdentifier' => 'module-yoast-overview',
         'labels' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModuleOverview.xlf',
@@ -35,7 +35,7 @@ return [
     ],
     'yoast_YoastSeoCrawler' => [
         'parent' => 'yoast',
-        'access' => 'user,group',
+        'access' => 'user',
         'path' => '/module/yoast/crawler',
         'iconIdentifier' => 'module-yoast-crawler',
         'labels' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModuleCrawler.xlf',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* fixes wrong access values in the Modules.php, which prevented Yoast groupMods from being available in the Backend user access list. See TYPO3 v12 Documentation for Backend module [access option](https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.html#confval-access).

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

*
 This PR can be tested by following these steps:
* Login to TYPO3
* Login to TYPO3 Backend
* Select the Backend Users module in the module list
* Select "Backend user groups" in the top menu
* Create a new Backend user group (or use an existing one)
* Select the Access Lists tab
* All Yoast Modules Access List (yoast_YoastSeoDashboard, yoast_YoastSeoOverview, yoast_YoastSeoCrawler) should now be be available.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [#545](https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues/545)
