### PR TITLE
[BUGFIX] Added extra checks within the metatag generators in case fields do not exist, fixed hasSitemapFields method with correct property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ We will follow [Semantic Versioning](http://semver.org/).
 ## UNRELEASED
 ### Fixed
 - Show warning on linking suggestions when content element is set to "All Languages" instead of fatal exception
+- Added extra checks within the metatag generators in case fields do not exist (opengraph, twitter, robots)
+- `hasSitemapFields` now correctly returns the `sitemapFields` instead of `yoastSeoFields`
 
 ## 9.0.1 July 6, 2023
 ### Fixed

--- a/Classes/MetaTag/AdvancedRobotsGenerator.php
+++ b/Classes/MetaTag/AdvancedRobotsGenerator.php
@@ -30,11 +30,11 @@ class AdvancedRobotsGenerator
             $record = $params['page'];
         }
 
-        $noImageIndex = (bool)$record['tx_yoastseo_robots_noimageindex'];
-        $noArchive = (bool)$record['tx_yoastseo_robots_noarchive'];
-        $noSnippet = (bool)$record['tx_yoastseo_robots_nosnippet'];
-        $noIndex = (bool)$record['no_index'];
-        $noFollow = (bool)$record['no_follow'];
+        $noImageIndex = (bool)($record['tx_yoastseo_robots_noimageindex'] ?? false);
+        $noArchive = (bool)($record['tx_yoastseo_robots_noarchive'] ?? false);
+        $noSnippet = (bool)($record['tx_yoastseo_robots_nosnippet'] ?? false);
+        $noIndex = (bool)($record['no_index'] ?? false);
+        $noFollow = (bool)($record['no_follow'] ?? false);
 
         if ($noImageIndex || $noArchive || $noSnippet || $noIndex || $noFollow) {
             $metaTagManagerRegistry = GeneralUtility::makeInstance(MetaTagManagerRegistry::class);

--- a/Classes/MetaTag/Generator/OpenGraphGenerator.php
+++ b/Classes/MetaTag/Generator/OpenGraphGenerator.php
@@ -26,7 +26,7 @@ class OpenGraphGenerator extends AbstractGenerator
             $manager->addProperty('og:description', $ogDescription);
         }
 
-        if ($record->getRecordData()['og_image']) {
+        if ($record->getRecordData()['og_image'] ?? false) {
             $fileCollector = GeneralUtility::makeInstance(FileCollector::class);
             $fileCollector->addFilesFromRelation($record->getTableName(), 'og_image', $record->getRecordData());
             $manager = $this->managerRegistry->getManagerForProperty('og:image');

--- a/Classes/MetaTag/Generator/TwitterGenerator.php
+++ b/Classes/MetaTag/Generator/TwitterGenerator.php
@@ -26,14 +26,14 @@ class TwitterGenerator extends AbstractGenerator
             $manager->addProperty('twitter:title', $twitterTitle);
         }
 
-        $twitterDescription = $record->getRecordData()['twitter_description'];
+        $twitterDescription = $record->getRecordData()['twitter_description'] ?? '';
         if (!empty($twitterDescription)) {
             $manager = $this->managerRegistry->getManagerForProperty('twitter:description');
             $manager->removeProperty('twitter:description');
             $manager->addProperty('twitter:description', $twitterDescription);
         }
 
-        if ($record->getRecordData()['twitter_image']) {
+        if ($record->getRecordData()['twitter_image'] ?? false) {
             $fileCollector = GeneralUtility::makeInstance(FileCollector::class);
             $fileCollector->addFilesFromRelation($record->getTableName(), 'twitter_image', $record->getRecordData());
             $manager = $this->managerRegistry->getManagerForProperty('twitter:image');

--- a/Classes/Record/Record.php
+++ b/Classes/Record/Record.php
@@ -59,7 +59,7 @@ class Record
 
     public function hasSitemapFields(): bool
     {
-        return $this->yoastSeoFields;
+        return $this->sitemapFields;
     }
 
     public function setSitemapFields(bool $sitemapFields): self


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Metatag generators could throw errors trying to access fields which were not available
* `hasSitemapFields` incorrectly returned `yoastSeoFields` instead of `sitemapFields`

## Relevant technical choices:

* Added `??` checks to the possibly non-existing fields

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Test if `setSitemapFields(false)` really does not add the fields in the backend
* Test if the frontend does not throw errors when fields in the database (like `og_image`) do no exist

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #550
