### PR TITLE
[BUGFIX] Filter the columns to import from the old premium database table before inserting in the new table within MigratePremiumFocusKeywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We will follow [Semantic Versioning](http://semver.org/).
 - Show warning on linking suggestions when content element is set to "All Languages" instead of fatal exception
 - Added extra checks within the metatag generators in case fields do not exist (opengraph, twitter, robots)
 - `hasSitemapFields` now correctly returns the `sitemapFields` instead of `yoastSeoFields`
+- Filter the columns to import from the old premium database table before inserting in the new table within `MigratePremiumFocusKeywords`
 
 ## 9.0.1 July 6, 2023
 ### Fixed


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The migration of the premium keywords could not only fail on `cruser_id`, but also when the premium table had other fields which were not present in the new table. This PR filters the array to insert by only allowing columns which are present in the new table.

## Relevant technical choices:

* Retrieve the columns from the `SchemaManager` and return it as a flipped array from the keys only, to use the `array_intersect_key` on every insert

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Manually add a column to the old `tx_yoast_seo_premium_focus_keywords` table (and make sure it contains records)
* Run the upgrade wizard and check for errors and if the data has been successfully migrated

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended