### PR TITLE
[BUGFIX] Fallback to default language within internal linking suggestions if All Languages is selected, changed language error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ We will follow [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
 ### Fixed
-- Show warning on linking suggestions when content element is set to "All Languages" instead of fatal exception
+- Show warning on linking suggestions when the language cannot be retrieved from the content element, use the default language in case "All Languages" is selected
 - Added extra checks within the metatag generators in case fields do not exist (opengraph, twitter, robots)
 - `hasSitemapFields` now correctly returns the `sitemapFields` instead of `yoastSeoFields`
 

--- a/Classes/Form/Element/InternalLinkingSuggestion.php
+++ b/Classes/Form/Element/InternalLinkingSuggestion.php
@@ -102,6 +102,10 @@ class InternalLinkingSuggestion extends AbstractNode
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
         try {
             $site = $siteFinder->getSiteByPageId($pageId);
+            if ($this->languageId === -1) {
+                $this->languageId = $site->getDefaultLanguage()->getLanguageId();
+                return $site->getDefaultLanguage()->getTwoLetterIsoCode();
+            }
             return $site->getLanguageById($this->languageId)->getTwoLetterIsoCode();
         } catch (SiteNotFoundException|\InvalidArgumentException $e) {
             return null;

--- a/Resources/Private/Language/BackendModule.xlf
+++ b/Resources/Private/Language/BackendModule.xlf
@@ -197,7 +197,7 @@
 				<source>Unable to determine linking suggestions.</source>
 			</trans-unit>
 			<trans-unit id="tx_yoastseo_linking_suggestions.languageError" resname="tx_yoastseo_linking_suggestions.languageError">
-				<source>This content element does not have a language to analyze.</source>
+				<source>There was a problem retrieving the language information for this content element, check your site configuration.</source>
 			</trans-unit>
 
 			<trans-unit id="page" xml:space="preserve">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* In https://github.com/Yoast/Yoast-SEO-for-TYPO3/pull/544 an error message was introduced when a content element has "All Language" as the language setting. This PR changes the behavior to use the default language instead, and only show the error when getting the language from the site configuration fails.

## Relevant technical choices:

* Use `getDefaultLanguage` of `Site` when `sys_language_uid` is `-1`.

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Set a content element to "All languages"
* Check if the internal linking suggestions are now based on the default language

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #554 