### PR TITLE
[BUGFIX] Fixed wrong label of tx_yoastseo_prominent_word table, removed exclude fields from table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+### Fixed
+- Missing label of the tx_yoastseo_prominent_word table
+- Removed exclude=true from tx_yoastseo_prominent_word fields, table already has hideTable
+
 ## 9.0.2 September 18, 2023
 ### Fixed
 - Show warning on linking suggestions when the language cannot be retrieved from the content element, use the default language in case "All Languages" is selected

--- a/Configuration/TCA/tx_yoastseo_prominent_word.php
+++ b/Configuration/TCA/tx_yoastseo_prominent_word.php
@@ -12,7 +12,6 @@ return [
     ],
     'columns' => [
         'stem' => [
-            'exclude' => 1,
             'label' => $llPrefix . 'tx_yoastseo_prominent_word.fields.stem',
             'config' => [
                 'type' => 'input',
@@ -21,7 +20,6 @@ return [
             ]
         ],
         'table' => [
-            'exclude' => 1,
             'label' => $llPrefix . 'tx_yoastseo_prominent_word.fields.table',
             'config' => [
                 'type' => 'input',
@@ -29,7 +27,6 @@ return [
             ]
         ],
         'weight' => [
-            'exclude' => 1,
             'label' => $llPrefix . 'tx_yoastseo_prominent_word.fields.weight',
             'config' => [
                 'type' => 'input',

--- a/Resources/Private/Language/TCA.xlf
+++ b/Resources/Private/Language/TCA.xlf
@@ -61,7 +61,7 @@
             <trans-unit id="tx_yoastseo_related_focuskeyword.fields.synonyms" resname="tx_yoastseo_related_focuskeyword.fields.synonyms">
                 <source>Synonyms</source>
             </trans-unit>
-            <trans-unit id="tx_yoastseo_prominent_word.fields.title" resname="tx_yoastseo_prominent_word.fields.title">
+            <trans-unit id="tx_yoastseo_prominent_word.title" resname="tx_yoastseo_prominent_word.title">
                 <source>Yoast SEO Prominent words</source>
             </trans-unit>
             <trans-unit id="tx_yoastseo_prominent_word.fields.stem" resname="tx_yoastseo_prominent_word.fields.stem">


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed the label of `tx_yoastseo_prominent_word`, wrong declaration within XLF file
* Removed the `exclude=1` of all the fields within the table

## Relevant technical choices:

* Since the `tx_yoastseo_prominent_word` table already has `hideTable=true` and the table is only used within AJAX requests, no need for exclude fields

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Check within the Access rights of backend user (groups) if the label is showing and if there are no exclude fields

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #561 