### PR TITLE
[DOCUMENTATION] Removed mentions of premium extension/support within documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ We will follow [Semantic Versioning](http://semver.org/).
 - Missing label of the tx_yoastseo_prominent_word table
 - Removed exclude=true from tx_yoastseo_prominent_word fields, table already has hideTable
 
+### Changed
+- Updated mentions of the premium extension within the documentation
+
 ## 9.0.2 September 18, 2023
 ### Fixed
 - Show warning on linking suggestions when the language cannot be retrieved from the content element, use the default language in case "All Languages" is selected

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -63,3 +63,8 @@ and help editors write high quality content.
    want support for your installation, you can buy our
    `premium plugin <https://yoast.com/typo3-extensions-seo/>`__ and get 24/7
    support.
+
+.. note::
+
+   The Yoast SEO Premium extension has been discontinued, all the features from
+   the extension have been migrated to the free version.

--- a/Documentation/Introduction/Support/Index.rst
+++ b/Documentation/Introduction/Support/Index.rst
@@ -21,10 +21,3 @@ Github
 
 Found a bug in the extension? Please report this in our
 `Github repository <https://github.com/Yoast/Yoast-SEO-for-TYPO3/issues>`__.
-
-Yoast Support
--------------
-
-If you purchased the premium extension, you'll have 24/7 access to the awesome support team at Yoast!
-
-`Find out more on the dedicated page on Yoast.com <https://yoast.com/help/support/#premium>`_


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The documentation still had a mention of Yoast Support with the premium extension, as this extension has been discontinued the support section has been deleted
* On the documentation index there's now a note that the premium extension has been discontinued

Fixes #560 