### PR TITLE
[BUGFIX] Use websiteTitle of site configuration for snippet preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We will follow [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Missing label of the tx_yoastseo_prominent_word table
 - Removed exclude=true from tx_yoastseo_prominent_word fields, table already has hideTable
+- Use `websiteTitle` of site configuration within snippet preview, previously this was only taken from site languages instead of the site itself
 
 ### Changed
 - Updated mentions of the premium extension within the documentation

--- a/Classes/Frontend/AdditionalPreviewData.php
+++ b/Classes/Frontend/AdditionalPreviewData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace YoastSeoForTypo3\YoastSeo\Frontend;
 
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -37,6 +38,10 @@ class AdditionalPreviewData implements SingletonInterface
         $language = $request->getAttribute('language');
         if ($language instanceof SiteLanguage && !empty($language->getWebsiteTitle())) {
             return trim($language->getWebsiteTitle());
+        }
+        $site = $request->getAttribute('site');
+        if ($site instanceof Site && !empty($site->getConfiguration()['websiteTitle'] ?? '')) {
+            return trim($site->getConfiguration()['websiteTitle']);
         }
 
         if (!empty($GLOBALS['TSFE']->tmpl->setup['sitetitle'] ?? '')) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Defining the website title within the snippet preview previously was only taken from `websiteTitle` of a site's language, now also the global `websiteTitle` is taken into account

## Relevant technical choices:

* Site attribute is taken from `TYPO3_REQUEST` and the `websiteTitle` is retrieved from `getConfiguration` just like in core

## Test instructions

This PR can be tested by following these steps:

* Pull branch
* Set `websiteTitle` within the site configuration
* Check a (sub) page of the site and start typing in the `seo_title` field, the website title should now stay in place

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #549 