### PR TITLE
Avoid PHP 8.4 deprecations

### DIFF
--- a/Classes/Backend/PageLayoutHeader.php
+++ b/Classes/Backend/PageLayoutHeader.php
@@ -24,7 +24,7 @@ class PageLayoutHeader
     /**
      * @param array<string, string>|null $params
      */
-    public function render(array $params = null, PageLayoutController|ModuleTemplate|null $parentObj = null): string
+    public function render(?array $params = null, PageLayoutController|ModuleTemplate|null $parentObj = null): string
     {
         $languageId = $this->getLanguageId();
         $pageId = (int)$_GET['id'];

--- a/Classes/Controller/AbstractBackendController.php
+++ b/Classes/Controller/AbstractBackendController.php
@@ -22,7 +22,7 @@ abstract class AbstractBackendController extends ActionController
     /**
      * @param array<string, mixed> $data
      */
-    protected function returnResponse(string $template, array $data = [], ModuleTemplate $moduleTemplate = null): ResponseInterface
+    protected function returnResponse(string $template, array $data = [], ?ModuleTemplate $moduleTemplate = null): ResponseInterface
     {
         $data['layout'] = GeneralUtility::makeInstance(Typo3Version::class)
             ->getMajorVersion() < 13 ? 'Default' : 'Module';

--- a/Classes/EventListener/RecordCanonicalListener.php
+++ b/Classes/EventListener/RecordCanonicalListener.php
@@ -13,7 +13,7 @@ class RecordCanonicalListener
 {
     protected RecordService $recordService;
 
-    public function __construct(RecordService $recordService = null)
+    public function __construct(?RecordService $recordService = null)
     {
         if ($recordService === null) {
             $recordService = GeneralUtility::makeInstance(RecordService::class);

--- a/Classes/MetaTag/Generator/AbstractGenerator.php
+++ b/Classes/MetaTag/Generator/AbstractGenerator.php
@@ -16,7 +16,7 @@ abstract class AbstractGenerator implements GeneratorInterface
 {
     protected MetaTagManagerRegistry $managerRegistry;
 
-    public function __construct(MetaTagManagerRegistry $managerRegistry = null)
+    public function __construct(?MetaTagManagerRegistry $managerRegistry = null)
     {
         if ($managerRegistry === null) {
             $managerRegistry = GeneralUtility::makeInstance(MetaTagManagerRegistry::class);

--- a/Classes/PageTitle/RecordPageTitleProvider.php
+++ b/Classes/PageTitle/RecordPageTitleProvider.php
@@ -13,7 +13,7 @@ class RecordPageTitleProvider extends AbstractPageTitleProvider
 {
     protected RecordService $recordService;
 
-    public function __construct(RecordService $recordService = null)
+    public function __construct(?RecordService $recordService = null)
     {
         if ($recordService === null) {
             $recordService = GeneralUtility::makeInstance(RecordService::class);

--- a/Classes/Utility/JavascriptUtility.php
+++ b/Classes/Utility/JavascriptUtility.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class JavascriptUtility
 {
-    public static function loadJavascript(PageRenderer $pageRenderer = null): void
+    public static function loadJavascript(?PageRenderer $pageRenderer = null): void
     {
         if ($pageRenderer === null) {
             $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Avoid PHP 8.4 deprecations

## Details

Fix the following deprecation messages when running `typo3 cache:flush` on console:

    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\Backend\PageLayoutHeader::render(): Implicitly marking parameter $params as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/Backend/PageLayoutHeader.php on line 27
    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\Controller\AbstractBackendController::returnResponse(): Implicitly marking parameter $moduleTemplate as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/Controller/AbstractBackendController.php on line 25
    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\EventListener\RecordCanonicalListener::__construct(): Implicitly marking parameter $recordService as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/EventListener/RecordCanonicalListener.php on line 16
    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\MetaTag\Generator\AbstractGenerator::__construct(): Implicitly marking parameter $managerRegistry as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/MetaTag/Generator/AbstractGenerator.php on line 19
    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\PageTitle\RecordPageTitleProvider::__construct(): Implicitly marking parameter $recordService as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/PageTitle/RecordPageTitleProvider.php on line 16
    PHP Deprecated:  YoastSeoForTypo3\YoastSeo\Utility\JavascriptUtility::loadJavascript(): Implicitly marking parameter $pageRenderer as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/yoast-seo-for-typo3/yoast_seo/Classes/Utility/JavascriptUtility.php on line 13

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended