### PR TITLE
Move yoast-advanced palette to SEO tab

### DIFF
--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -252,7 +252,7 @@ class TcaService
             $this->table,
             '--palette--;' . self::LL_PREFIX_TCA . 'pages.palettes.advances;yoast-advanced,',
             $this->types,
-            'after: twitter_image'
+            'after: sitemap_priority'
         );
     }
 


### PR DESCRIPTION
Currently the palette `yoast-advanced` with the Field `tx_yoastseo_hide_snippet_preview ` is placed in the "Social Media" Tab after the `twitter_image`. Should be moved to the SEO tab.

## Summary

This PR can be summarized in the following changelog entry:

* Palette `yoast-advanced` moved to SEO tab in page details

## Relevant technical choices:

* Optimze UX in for the editor

## Test instructions

This PR can be tested by following these steps:

* Apply the TCA change and open die page details in the backend.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

