### PR TITLE
[TASK] Add security configuration to ignore page type restrictions

### DIFF
--- a/Configuration/TCA/tx_yoastseo_prominent_word.php
+++ b/Configuration/TCA/tx_yoastseo_prominent_word.php
@@ -9,6 +9,9 @@ return [
         'languageField' => 'sys_language_uid',
         'iconfile' => 'EXT:yoast_seo/Resources/Public/Icons/Extension.svg',
         'hideTable' => true,
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
     ],
     'columns' => [
         'stem' => [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Add security configuration to ignore page type restrictions for `tx_yoastseo_prominent_word` table.

## Relevant technical choices:

* Added the `security` configuration in the `ctrl` section with `ignorePageTypeRestriction` set to `true`.
* See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98487-TCAOptionCtrlsecurityignorePageTypeRestriction.html

## Test instructions

This PR can be tested by following these steps:

Duplicate one or more pages that contain at least one record of `tx_yoastseo_prominent_word`. As long as there is no flash message, respectively sys_log entry, popping up that says: `Attempt to insert record "tx_yoastseo_prominent_word:123" on a page (456) that can't store record type`, the test was successful.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #602