### PR TITLE
[BUGFIX] Added missing translations and supportedLanguages javascript configuration for the Crawler module

### DIFF
--- a/Classes/Service/Crawler/CrawlerJavascriptConfigService.php
+++ b/Classes/Service/Crawler/CrawlerJavascriptConfigService.php
@@ -7,6 +7,7 @@ namespace YoastSeoForTypo3\YoastSeo\Service\Crawler;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use YoastSeoForTypo3\YoastSeo\Service\Javascript\JavascriptService;
 use YoastSeoForTypo3\YoastSeo\Service\Javascript\JsonConfigService;
+use YoastSeoForTypo3\YoastSeo\Service\LocaleService;
 use YoastSeoForTypo3\YoastSeo\Utility\PathUtility;
 
 class CrawlerJavascriptConfigService
@@ -14,7 +15,8 @@ class CrawlerJavascriptConfigService
     public function __construct(
         protected JavascriptService $javascriptService,
         protected JsonConfigService $jsonConfigService,
-        protected UriBuilder $uriBuilder
+        protected UriBuilder $uriBuilder,
+        protected LocaleService $localeService
     ) {}
 
     public function addJavascriptConfig(): void
@@ -28,6 +30,8 @@ class CrawlerJavascriptConfigService
                 'indexPages' => (string)$this->uriBuilder->buildUriFromRoute('ajax_yoast_crawler_index_pages'),
                 'prominentWords' => (string)$this->uriBuilder->buildUriFromRoute('ajax_yoast_prominent_words'),
             ],
+            'translations' => [$this->localeService->getTranslations()],
+            'supportedLanguages' => $this->localeService->getSupportedLanguages(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With the latest javascript changes the `translations` and `supportedLanguages` configuration is needed, this was missing in the crawler functionality and has now been added

## Relevant technical choices:

* `LocaleService` is injected into `CrawlerJavascriptConfigService` to retrieve the translations and supported languages

## Test instructions

This PR can be tested by following these steps:

* Visit the Crawler backend module and test the indexing of pages

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #604
