### PR TITLE
[BUGFIX] Fallback to en_GB if no backend locale is found to prevent missing javascript translations

### DIFF
--- a/Classes/Service/LocaleService.php
+++ b/Classes/Service/LocaleService.php
@@ -32,7 +32,8 @@ class LocaleService
         $interfaceLocale = $this->getInterfaceLocale();
 
         if ($interfaceLocale === null) {
-            return [];
+            // Fall back to English if no suitable locale could be resolved to prevent missing translations
+            $interfaceLocale = 'en_GB';
         }
 
         $translationFilePath = GeneralUtility::getFileAbsFileName(


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* If the `interfaceLocale` (backend language) cannot be retrieved, we now fall back to `en_GB` to prevent the translations missing in javascript

## Relevant technical choices:

* Instead of returning an empty array the `$interfaceLocale` is set to `en_GB`

## Test instructions

This PR can be tested by following these steps:

* Check if the correct language is still taken correctly from your user settings

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #599
