### PR TITLE
[BUGFIX] Required typo3/tailor to fix automatic publishing of extension to TER

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     "phpunit/phpunit": "^10.1",
     "saschaegerer/phpstan-typo3": "^1.10",
     "typo3/coding-standards": "^0.7.1 || ^0.8.0",
+    "typo3/tailor": "^1.7",
     "typo3/testing-framework": "^7.1.0 || ^8.2.0"
   },
   "replace": {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With the latest major release there were a lot of new (dev) composer requirements where the versions were matched to prevent collision of underlying package versions (like symfony packages). Somewhere `typo3/tailor` was removed which is needed for automatic publishing to the TER.

## Relevant technical choices:

* Required the latest version 1.7 of `typo3/tailor` which should contain bugfixes to fix the package against the latest changes in TER

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended