### PR TITLE
[FEATURE] Feature toggle to completely disable cache for the page preview request to prevent edge-case caching issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- Feature toggle to completely disable cache for the page preview request to prevent edge-case caching issues
+
 ## 11.1.0 July 1, 2025
 
 ### Added

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -16,15 +17,23 @@ use YoastSeoForTypo3\YoastSeo\Service\YoastRequestService;
 class PageRequestMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        protected YoastRequestService $yoastRequestService
+        protected YoastRequestService $yoastRequestService,
+        protected Features $features,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if ($this->yoastRequestService->isValidRequest($request->getServerParams())) {
-            $context = GeneralUtility::makeInstance(Context::class);
-            $context->setAspect('visibility', new VisibilityAspect(true));
+        if (!$this->yoastRequestService->isValidRequest($request->getServerParams())) {
+            return $handler->handle($request);
         }
+
+        $context = GeneralUtility::makeInstance(Context::class);
+        $context->setAspect('visibility', new VisibilityAspect(true));
+
+        if ($this->features->isFeatureEnabled('yoastSeoDisableAllCachesOnPreviewRequest')) {
+            $request = $request->withAttribute('noCache', true);
+        }
+
         return $handler->handle($request);
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -59,4 +59,6 @@ defined('TYPO3') || die;
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['yoastseo_recordcache'] ??= [];
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['yoastseo_recordcache']['groups'] ??= ['system'];
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['yoastSeoDisableAllCachesOnPreviewRequest'] ??= false;
 })();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* A new feature toggle `yoastSeoDisableAllCachesOnPreviewRequest` has been introduced to completely disable cache (`no_cache=1`) when the preview request is executed on the frontend
* This feature is disabled by default because it hurts performance but is needed in some edge-cases where hidden pages would get cached in custom caches as we set the `VisibilityAspect` to include hidden pages

## Test instructions

This PR can be tested by following these steps:

* Use some kind of typoscript lib which has it's own cache and requests pages
* Make sure there are hidden pages
* Clear the caches and load a page in the backend to make sure the preview is executed
* Hidden page(s) should be in the cache now
* Enable the new `yoastSeoDisableAllCachesOnPreviewRequest` feature
* The problem above should not occur anymore

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
