### PR TITLE
[BUGFIX] Re-introduce typo3/tailor for automatic TER publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     name: Publish new version to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Re-introduced typo3/tailor for automatic TER publishing
+- Set publish workflow to run on ubuntu-latest to fix PHP compatibility errors
+
 ## 12.0.0 April 21, 2026
 
 ### Breaking

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "phpunit/phpunit": "^10.1 || ^11.2.5",
         "saschaegerer/phpstan-typo3": "^1.10 || ^2.1 || ^3.0.1",
         "typo3/coding-standards": "^0.7.1 || ^0.8.0",
+        "typo3/tailor": "^1.7",
         "typo3/testing-framework": "^7.1.0 || ^8.2.0 || ^9.5.0"
     },
     "replace": {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* With all the dependency changes for version 12 the package `typo3/tailor` was accidentally deleted which meant the extension was not automatically published to TER.
* The call to `bin/tailor` wouldn't even have worked because the `publish` workflow still used `ubuntu-22.04` which had PHP8.1 and we now require PHP8.2 as minimal

## Relevant technical choices:

* `typo3/tailor` is back in the `composer.json` dependencies
* Used `ubuntu-latest` as runner for the publish workflow

## Test instructions

This PR can be tested by following these steps:

* Unfortunately this can only be tested with a new release, running the command locally has already published the current 12.0.0 to TER

## Quality assurance

* [X] I have tested this code to the best of my abilities