### PR TITLE
[BUGFIX] Do not preview website title if config.showWebsiteTitle is false

### DIFF
--- a/Classes/Frontend/AdditionalPreviewData.php
+++ b/Classes/Frontend/AdditionalPreviewData.php
@@ -52,6 +52,9 @@ class AdditionalPreviewData implements SingletonInterface
 
     protected function getWebsiteTitle(): string
     {
+        if ((bool)($this->config['showWebsiteTitle'] ?? false) === false) {
+            return '';
+        }
         $request = $GLOBALS['TYPO3_REQUEST'];
         $language = $request->getAttribute('language');
         if ($language instanceof SiteLanguage && !empty($language->getWebsiteTitle())) {
@@ -61,11 +64,6 @@ class AdditionalPreviewData implements SingletonInterface
         if ($site instanceof Site && !empty($site->getConfiguration()['websiteTitle'] ?? '')) {
             return trim($site->getConfiguration()['websiteTitle']);
         }
-
-        if (!empty($GLOBALS['TSFE']->tmpl->setup['sitetitle'] ?? '')) {
-            return trim($GLOBALS['TSFE']->tmpl->setup['sitetitle']);
-        }
-
         return '';
     }
 


### PR DESCRIPTION
## Test instructions

This PR can be tested by following these steps:

* Set Typoscipt config.showWebsiteTitle = 0 and have a website title configured in the site you still see the title in the preview sometimes

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended

Fixes #654
