### PR TITLE
[BUGFIX] Split up user setting field registration between 12/13 and 14 to fix exception

### DIFF
--- a/Build/phpstan/phpstan.cms12.neon
+++ b/Build/phpstan/phpstan.cms12.neon
@@ -12,6 +12,7 @@ parameters:
     - '#TYPO3\\CMS\\Frontend\\Page\\PageInformation#'
     - '#frontend.page.information#'
     - '#BeforePageCacheIdentifierIsHashedEvent#'
+    - '#addUserSetting#'
   typo3:
     requestGetAttributeMapping:
         handlerRequest: string

--- a/Build/phpstan/phpstan.cms13.neon
+++ b/Build/phpstan/phpstan.cms13.neon
@@ -11,6 +11,7 @@ parameters:
     - ../../Classes/Service/StandaloneView/LegacyStandaloneViewService.php
   ignoreErrors:
     - '#defaultCacheTimoutInSeconds#'
+    - '#addUserSetting#'
   typo3:
     requestGetAttributeMapping:
         frontend.page.information: TYPO3\CMS\Frontend\Page\PageInformation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Split up the user settings field for 12/13 and 14 to prevent issues with the TCA changes in TYPO3 14
+
 ## 12.1.0 May 8, 2026
 
 ### Changed

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+defined('TYPO3') || die;
+
+if ((new Typo3Version())->getMajorVersion() >= 14) {
+    // @todo: using addUserSetting removed the custom Yoast SEO tab, maybe restore this in the future if needed?
+
+    ExtensionManagementUtility::addUserSetting(
+        'hideYoastInPageModule',
+        [
+            'label' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:usersettings.hideYoastInPageModule',
+            'config' => [
+                'renderType' => 'checkboxToggle',
+                'type' => 'check',
+            ],
+        ],
+    );
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -7,19 +7,22 @@
  * LICENSE.txt file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use YoastSeoForTypo3\YoastSeo\Hooks\BackendYoastTranslations;
 
 defined('TYPO3') || die;
 
-// Extend user settings
-$GLOBALS['TYPO3_USER_SETTINGS']['columns']['hideYoastInPageModule'] = [
-    'label' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:usersettings.hideYoastInPageModule',
-    'type' => 'check',
-];
-ExtensionManagementUtility::addFieldsToUserSettings(
-    '--div--;LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:usersettings.title,hideYoastInPageModule'
-);
+// Extend user settings (see Configuration/Overrides/be_users.php for TYPO3 v14 and above)
+if ((new Typo3Version())->getMajorVersion() < 14) {
+    $GLOBALS['TYPO3_USER_SETTINGS']['columns']['hideYoastInPageModule'] = [
+        'label' => 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:usersettings.hideYoastInPageModule',
+        'type' => 'check',
+    ];
+    ExtensionManagementUtility::addFieldsToUserSettings(
+        '--div--;LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:usersettings.title,hideYoastInPageModule'
+    );
+}
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][]
     = BackendYoastTranslations::class . '->renderTranslations';


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Due to the new TCA setup of the user settings in TYPO3 14 the old configuration produced an exception inside the User settings module.

## Relevant technical choices:

* Because the old syntax is not supported in 14 but the new syntax is not supported in 12 and 13, the registration has been split up in `ext_tables.php` and `Configuration/TCA/Overrides/be_users.php`
* Added a `@todo` to check in the feature if the "Yoast SEO" tab can be restored for version 14, it is now just at the bottom of the last tab 

## Test instructions

This PR can be tested by following these steps:

* Check if the User settings works in TYPO3 12, 13 and 14

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #657 
