### PR TITLE
[BUGFIX] Fix exception when editing records with sys_language_uid -1

### DIFF
--- a/Classes/Service/SiteService.php
+++ b/Classes/Service/SiteService.php
@@ -58,6 +58,10 @@ class SiteService
             return '';
         }
 
+        if ($languageId === -1) {
+            $languageId = $site->getDefaultLanguage()->getLanguageId();
+        }
+
         $language = $site->getLanguageById($languageId);
         if (trim($language->getWebsiteTitle()) !== '') {
             return $language->getWebsiteTitle();


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fix exception when editing records with sys_language_uid -1

## Test instructions

This PR can be tested by following these steps:

* Edit a record in the TYPO3 backend that has `sys_language_uid -1`

## Quality assurance

* [X ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #665
