### PR TITLE
[BUGFIX] Exclude TYPO3 12 tests from security advisories to prevent failing tests

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -496,6 +496,11 @@ case ${TEST_SUITE} in
         stashComposerFiles
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-highest-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/bash -c "
             if [ ${TYPO3_VERSION} -eq 12 ]; then
+              # TYPO3 12.4 has reached the end of regular maintenance: advisory fixes
+              # (12.4.47+) are only shipped via ELTS (private). The latest public 12.4
+              # release will therefore always be flagged, so disable advisory blocking
+              # for v12 to keep CI running against the newest available public release.
+              composer config --no-plugins policy.advisories.block false || exit 1
               composer require --no-ansi --no-interaction --no-progress --no-install \
                 typo3/cms-core:^12.4 typo3/cms-dashboard:^12.4 || exit 1
             fi
@@ -518,6 +523,11 @@ case ${TEST_SUITE} in
         stashComposerFiles
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-lowest-${SUFFIX} -e COMPOSER_CACHE_DIR=.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/bash -c "
             if [ ${TYPO3_VERSION} -eq 12 ]; then
+              # TYPO3 12.4 has reached the end of regular maintenance: advisory fixes
+              # (12.4.47+) are only shipped via ELTS (private). The latest public 12.4
+              # release will therefore always be flagged, so disable advisory blocking
+              # for v12 to keep CI running against the newest available public release.
+              composer config --no-plugins policy.advisories.block false || exit 1
               composer require --no-ansi --no-interaction --no-progress --no-install \
                 typo3/cms-core:^12.4 typo3/cms-dashboard:^12.4 || exit 1
             fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* The latest publicly available 12 version is under security advisory so the composer build fails, cannot depend on ELTS repository so advisory is disabled for (only) the 12 version

## Relevant technical choices:

* Directly adjusted in the `.sh` script so this will be automatically removed when 12 support is dropped

## Test instructions

This PR can be tested by following these steps:

* See if the tests succeed in this PR

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended