### PR TITLE
[BUGFIX] Check if columns for seo/readability score exist before saving inside SaveScoresService

### DIFF
--- a/Build/extensions/sitepackage/Configuration/TCA/Overrides/tx_sitepackage_domain_model_manual.php
+++ b/Build/extensions/sitepackage/Configuration/TCA/Overrides/tx_sitepackage_domain_model_manual.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+$llPrefix = 'LLL:EXT:yoast_seo/Resources/Private/Language/BackendModule.xlf:';
+ExtensionManagementUtility::addTCAcolumns(
+    'tx_sitepackage_domain_model_manual',
+    [
+        'tx_yoastseo_snippetpreview' => [
+            'label' => $llPrefix . 'snippetPreview',
+            'exclude' => true,
+            'displayCond' => 'REC:NEW:false',
+            'config' => [
+                'type' => 'none',
+                'renderType' => 'snippetPreview',
+                'settings' => [
+                    'titleField' => 'seo_title',
+                    'descriptionField' => 'seo_description',
+                ],
+            ],
+        ],
+        'tx_yoastseo_readability_analysis' => [
+            'label' => $llPrefix . 'analysis',
+            'exclude' => true,
+            'config' => [
+                'type' => 'none',
+                'renderType' => 'readabilityAnalysis',
+            ],
+        ],
+        'tx_yoastseo_focuskeyword' => [
+            'label' => $llPrefix . 'seoFocusKeyword',
+            'exclude' => true,
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+        'tx_yoastseo_focuskeyword_analysis' => [
+            'label' => $llPrefix . 'analysis',
+            'exclude' => true,
+            'config' => [
+                'type' => 'none',
+                'renderType' => 'focusKeywordAnalysis',
+                'settings' => [
+                    'focusKeywordField' => 'tx_yoastseo_focuskeyword',
+                ],
+            ],
+        ],
+    ]
+);
+
+ExtensionManagementUtility::addFieldsToPalette(
+    'tx_sitepackage_domain_model_manual',
+    'yoast-metadata',
+    '
+--linebreak--, tx_yoastseo_snippetpreview,
+--linebreak--, seo_title,
+--linebreak--, seo_description,
+'
+);
+
+ExtensionManagementUtility::addFieldsToPalette(
+    'tx_sitepackage_domain_model_manual',
+    'yoast-focuskeyword',
+    '
+--linebreak--, tx_yoastseo_focuskeyword,
+--linebreak--, tx_yoastseo_focuskeyword_analysis
+'
+);
+
+ExtensionManagementUtility::addFieldsToPalette(
+    'tx_sitepackage_domain_model_manual',
+    'yoast-readability',
+    '
+--linebreak--, tx_yoastseo_readability_analysis
+'
+);
+
+ExtensionManagementUtility::addToAllTCAtypes(
+    'tx_sitepackage_domain_model_manual',
+    '
+--div--;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.tabs.seo,
+--palette--;;yoast-metadata,
+--palette--;;yoast-readability,
+--palette--;;yoast-focuskeyword,
+',
+    '',
+    'after:text'
+);

--- a/Build/extensions/sitepackage/Configuration/TCA/tx_sitepackage_domain_model_manual.php
+++ b/Build/extensions/sitepackage/Configuration/TCA/tx_sitepackage_domain_model_manual.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+return [
+    'ctrl' => [
+        'title' => 'Manual TCA Record Example',
+        'label' => 'title',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'cruser_id' => 'cruser_id',
+        'languageField' => 'sys_language_uid',
+        'iconfile' => 'EXT:sitepackage/Resources/Public/Icons/Icon.svg',
+    ],
+    'types' => [
+        '1' => ['showitem' => 'title, text, sys_language_uid'],
+    ],
+    'columns' => [
+        'title' => [
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+        'text' => [
+            'label' => 'Text',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 15,
+                'enableRichtext' => true,
+                'richtextConfiguration' => 'minimal',
+            ],
+        ],
+        'seo_title' => [
+            'label' => 'SEO Title',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+            ],
+        ],
+        'seo_description' => [
+            'label' => 'SEO Description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3,
+            ],
+        ],
+        'sys_language_uid' => [
+            'label' => 'Language',
+            'config' => [
+                'type' => 'language',
+            ],
+        ],
+    ],
+];

--- a/Build/extensions/sitepackage/ext_tables.sql
+++ b/Build/extensions/sitepackage/ext_tables.sql
@@ -5,3 +5,14 @@ CREATE TABLE tx_sitepackage_domain_model_minimal (
    title varchar(255) NOT NULL DEFAULT '',
    text text NOT NULL DEFAULT '',
 );
+
+#
+# Table structure for 'tx_sitepackage_domain_model_manual'
+#
+CREATE TABLE tx_sitepackage_domain_model_manual (
+   title varchar(255) NOT NULL DEFAULT '',
+   text text NOT NULL DEFAULT '',
+   seo_title varchar(255) NOT NULL DEFAULT '',
+   seo_description varchar(255) NOT NULL DEFAULT '',
+   tx_yoastseo_focuskeyword varchar(100) DEFAULT '' NOT NULL,
+);

--- a/Classes/Service/SaveScoresService.php
+++ b/Classes/Service/SaveScoresService.php
@@ -39,6 +39,9 @@ class SaveScoresService
         }
 
         $connection = $this->connectionPool->getConnectionForTable($data['table']);
+        if (!$this->columnsExist($connection, $data['table'])) {
+            return;
+        }
         $connection->update($data['table'], [
             'tx_yoastseo_score_readability' => (string)$data['readabilityScore'],
             'tx_yoastseo_score_seo' => (string)$data['seoScore'],
@@ -96,5 +99,12 @@ class SaveScoresService
         }
         $record = $queryBuilder->executeQuery()->fetchAssociative();
         return $record === false ? null : $record;
+    }
+
+    protected function columnsExist(Connection $connection, string $table): bool
+    {
+        $schemaManager = $connection->createSchemaManager();
+        $columns = $schemaManager->listTableColumns($table);
+        return isset($columns['tx_yoastseo_score_readability'], $columns['tx_yoastseo_score_seo']);
     }
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* When manually adding the Yoast SEO fields through TCA on a custom record but **not** adding the seo/readability score fields in the database an exception occurs on the `savescores` endpoint, this PR checks if the columns exist before saving

## Relevant technical choices:

* Using the `SchemaManager` to check the database columns

## Test instructions

This PR can be tested by following these steps:

* Using the https://docs.typo3.org/p/yoast-seo-for-typo3/yoast_seo/12.1/en-us/Configuration/OtherPlugins/Manual/Index.html documentation to add the fields on a custom record, check the response of the `savescores` endpoint to see if no exception occurs

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #658 