### PR TITLE
[BUGFIX] RecordCanonicalListener now uses standalone ContentObjectRenderer for TYPO3 13 and 14

### DIFF
--- a/Classes/EventListener/RecordCanonicalListener.php
+++ b/Classes/EventListener/RecordCanonicalListener.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace YoastSeoForTypo3\YoastSeo\EventListener;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
 use YoastSeoForTypo3\YoastSeo\Record\Record;
@@ -35,15 +36,21 @@ class RecordCanonicalListener
         }
 
         $event->setUrl(
-            $this->getContentObjectRenderer()->typoLink_URL([
-                'parameter' => $canonicalLink,
-                'forceAbsoluteUrl' => true,
-            ])
+            $this->getUrl($event, $canonicalLink, $activeRecord)
         );
     }
 
-    protected function getContentObjectRenderer(): ContentObjectRenderer
-    {
-        return $GLOBALS['TSFE']->cObj;
+    protected function getUrl(
+        ModifyUrlForCanonicalTagEvent $event,
+        string $canonicalLink,
+        Record $record,
+    ): string {
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $cObj->setRequest($event->getRequest());
+        $cObj->start($record->getRecordData(), $record->getTableName());
+        return $cObj->createUrl([
+            'parameter' => $canonicalLink,
+            'forceAbsoluteUrl' => true,
+        ]);
     }
 }

--- a/Tests/Unit/EventListener/RecordCanonicalListenerTest.php
+++ b/Tests/Unit/EventListener/RecordCanonicalListenerTest.php
@@ -14,6 +14,7 @@ namespace YoastSeoForTypo3\YoastSeo\Tests\Unit\EventListener;
 use DG\BypassFinals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -69,12 +70,13 @@ class RecordCanonicalListenerTest extends UnitTestCase
         $event = $this->createMock(ModifyUrlForCanonicalTagEvent::class);
         $record = $this->createMock(Record::class);
         $record->method('getRecordData')->willReturn(['canonical_link' => 'https://example.com']);
+        $record->method('getTableName')->willReturn('pages');
 
         $this->recordService->method('getActiveRecord')->willReturn($record);
 
-        $GLOBALS['TSFE'] = $this->createMock(\stdClass::class);
-        $GLOBALS['TSFE']->cObj = $this->createMock(ContentObjectRenderer::class);
-        $GLOBALS['TSFE']->cObj->method('typoLink_URL')->willReturn('https://example.com');
+        $contentObjectRenderer = $this->createMock(ContentObjectRenderer::class);
+        $contentObjectRenderer->method('createUrl')->willReturn('https://example.com');
+        GeneralUtility::addInstance(ContentObjectRenderer::class, $contentObjectRenderer);
 
         $event->expects(self::once())->method('setUrl')->with('https://example.com');
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* `RecordCanonicalListener` still used `$GLOBALS['TSFE']` for retrieving the `ContentObjectRenderer`, there is now a check on the TSFE and fallback to the way the `CanonicalGenerator` creates the `ContentObjectRenderer`

## Relevant technical choices:

* Using the if check on `TSFE` only the if statement needs to be removed when 12 support is dropped

## Test instructions

This PR can be tested by following these steps:

* Add a canonical link on a custom record and check if it renders correctly in the frontend for all versions

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended