### PR TITLE
[BUGFIX] Code coverage now includes functional instead unit two times, added extra excluded directories/files for TER release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,23 +42,23 @@ jobs:
         run: Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php }} -s unit
 
       - name: Functional tests coverage
-        if: matrix.php == '8.2' && matrix.typo3 == '13' && matrix.composerInstall == 'composerInstallHighest'
-        run: Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php }} -s unit -x -e "--coverage-php=.Build/coverage/functional.cov"
+        if: matrix.php == '8.2' && matrix.typo3 == '14' && matrix.composerInstall == 'composerInstallHighest'
+        run: Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php }} -s functional -x -e "--coverage-php=.Build/coverage/functional.cov"
 
       - name: Unit tests coverage
-        if: matrix.php == '8.2' && matrix.typo3 == '13' && matrix.composerInstall == 'composerInstallHighest'
+        if: matrix.php == '8.2' && matrix.typo3 == '14' && matrix.composerInstall == 'composerInstallHighest'
         run: Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php }} -s unit -x -e "--coverage-php=.Build/coverage/unit.cov"
 
       - name: Composer require phpunit/phpcov for merging the code coverage
-        if: matrix.php == '8.2' && matrix.typo3 == '13' && matrix.composerInstall == 'composerInstallHighest'
+        if: matrix.php == '8.2' && matrix.typo3 == '14' && matrix.composerInstall == 'composerInstallHighest'
         run: Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php }} -s composer require --dev phpunit/phpcov
 
       - name: Merge coverage
-        if: matrix.php == '8.2' && matrix.typo3 == '13' && matrix.composerInstall == 'composerInstallHighest'
+        if: matrix.php == '8.2' && matrix.typo3 == '14' && matrix.composerInstall == 'composerInstallHighest'
         run: ./.Build/bin/phpcov merge --clover=build/logs/clover.xml .Build/coverage
 
       - name: Upload coverage
-        if: matrix.php == '8.2' && matrix.typo3 == '13' && matrix.composerInstall == 'composerInstallHighest'
+        if: matrix.php == '8.2' && matrix.typo3 == '14' && matrix.composerInstall == 'composerInstallHighest'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/Build/ExcludeFromPackaging.php
+++ b/Build/ExcludeFromPackaging.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
 return [
     'directories' => [
         'bin',
@@ -16,7 +23,9 @@ return [
         'tailor-version-upload',
         'Documentation-GENERATED-temp',
         'tests',
+        'Tests',
         'vendor',
+        'var',
         '.Build',
         'Build',
         'grunt',
@@ -28,6 +37,7 @@ return [
         'bower.json',
         'babel.config.js',
         'codeception.yml',
+        'composer.json.testing',
         'composer.lock',
         'crowdin.yaml',
         'docker-compose.yml',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Code coverage inside github workflows executed `unit` 2 times instead of `functional` + `unit`, this is now corrected
* Coverage is now based on TYPO3 14 instead of 13
* Added extra directories and folders to `ExcludeFromPackaging.php`

## Test instructions

This PR can be tested by following these steps:

* See this PR's tests

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended