### PR TITLE
[BUGFIX] Updated LinkingSuggestionsService to sort correctly and base batchSize of group sizes

### DIFF
--- a/Classes/Service/LinkingSuggestionsService.php
+++ b/Classes/Service/LinkingSuggestionsService.php
@@ -37,6 +37,7 @@ class LinkingSuggestionsService
         protected ConnectionPool $connectionPool,
         protected PageRepository $pageRepository,
         protected SiteService $siteService,
+        protected int $batchSize = 100,
     ) {}
 
     /**
@@ -57,8 +58,25 @@ class LinkingSuggestionsService
         $this->languageId = $languageId;
         $this->documentFrequencyCache = [];
 
-        $words = array_column($words, 'occurrences', 'stem');
+        $scores = $this->collectScores(array_column($words, 'occurrences', 'stem'));
 
+        // Return the empty list if no suggestions have been found.
+        if ($scores === []) {
+            return [];
+        }
+
+        return $this->linkRecords($scores, $this->getCurrentContentLinks($content));
+    }
+
+    /**
+     * Score every candidate record that shares prominent word stems with the request, paging
+     * through the prominent word table in batches of {@see self::$batchSize} record groups.
+     *
+     * @param array<string, int|string> $words stem => occurrences
+     * @return array<string, float|int> record key (uid_foreign-tablenames) => normalized score
+     */
+    protected function collectScores(array $words): array
+    {
         // Combine stems, weights and DFs from request
         $requestData = $this->composeRequestData($words);
 
@@ -67,34 +85,30 @@ class LinkingSuggestionsService
 
         $requestStems = array_keys($requestData);
         $scores = [];
-        $batchSize = 100;
         $page = 1;
 
         do {
-            // Retrieve the words of all records in this batch that share prominent word stems with request
-            $candidatesWords = $this->getCandidateWords($requestStems, $batchSize, $page);
+            // Retrieve the (pid, tablenames) record groups for this batch that share stems with the request
+            $recordGroups = $this->findRecordsByStems($requestStems, $this->batchSize, $page);
 
-            // Transform the prominent words table so that it indexed by record
+            // Expand the groups into their prominent words and index them by record
+            $candidatesWords = $this->findStemsByRecords($recordGroups);
             $candidatesWordsByRecord = $this->groupWordsByRecord($candidatesWords);
 
-            $batchScoresSize = 0;
             foreach ($candidatesWordsByRecord as $id => $candidateData) {
                 $scores[$id] = $this->calculateScoreForIndexable($requestData, $requestVectorLength, $candidateData);
-                ++$batchScoresSize;
             }
 
             // Sort the list of scores and keep only the top of the scores
             $scores = $this->getTopSuggestions($scores);
 
             ++$page;
-        } while ($batchScoresSize === $batchSize);
+            // Keep paging while the batch was full. The loop must count the paged unit
+            // (record groups), not the scored records, because a single group can expand
+            // into several records and would otherwise stop paging too early.
+        } while (count($recordGroups) === $this->batchSize);
 
-        // Return the empty list if no suggestions have been found.
-        if ($scores === []) {
-            return [];
-        }
-
-        return $this->linkRecords($scores, $this->getCurrentContentLinks($content));
+        return $scores;
     }
 
     /**
@@ -185,17 +199,6 @@ class LinkingSuggestionsService
     }
 
     /**
-     * @param string[] $stems
-     * @return array<array{stem: string, weight: int, pid: int, tablenames: string, uid_foreign: int, df?: int}>
-     */
-    protected function getCandidateWords(array $stems, int $batchSize, int $page): array
-    {
-        return $this->findStemsByRecords(
-            $this->findRecordsByStems($stems, $batchSize, $page)
-        );
-    }
-
-    /**
      * @param array<array{pid: int, tablenames: string}> $records
      * @return array<array{stem: string, weight: int, pid: int, tablenames: string, uid_foreign: int, df?: int}>
      */
@@ -234,6 +237,8 @@ class LinkingSuggestionsService
             $queryBuilder->expr()->eq('sys_language_uid', $this->languageId),
             $queryBuilder->expr()->eq('site', $this->site)
         )->groupBy('pid', 'tablenames')
+            ->orderBy('pid')
+            ->addOrderBy('tablenames')
             ->setMaxResults($batchSize)
             ->setFirstResult(($page - 1) * $batchSize);
         /** @var array<array{pid: int, tablenames: string}> $records */

--- a/Tests/Functional/Fixtures/linking_suggestions_paging.csv
+++ b/Tests/Functional/Fixtures/linking_suggestions_paging.csv
@@ -1,0 +1,6 @@
+"tx_yoastseo_prominent_word"
+,"uid","pid","sys_language_uid","site","stem","weight","uid_foreign","tablenames"
+,1,1,0,1,"seo",10,1,"pages"
+,2,1,0,1,"seo",10,100,"pages"
+,3,2,0,1,"seo",10,2,"pages"
+,4,3,0,1,"seo",10,3,"pages"

--- a/Tests/Functional/Service/LinkingSuggestionsServiceTest.php
+++ b/Tests/Functional/Service/LinkingSuggestionsServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace YoastSeoForTypo3\YoastSeo\Tests\Functional\Service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use YoastSeoForTypo3\YoastSeo\Service\LinkingSuggestionsService;
+use YoastSeoForTypo3\YoastSeo\Service\SiteService;
+use YoastSeoForTypo3\YoastSeo\Tests\Functional\AbstractFunctionalTestCase;
+
+#[CoversClass(LinkingSuggestionsService::class)]
+class LinkingSuggestionsServiceTest extends AbstractFunctionalTestCase
+{
+    protected ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/linking_suggestions_paging.csv');
+
+        $this->connectionPool = $this->getContainer()->get(ConnectionPool::class);
+    }
+
+    /**
+     * Three (pid, tablenames) record groups share the request stem. With a batch size of two,
+     * the first page holds two groups (pids 1 and 2), but pid 1 contains two analyzed records,
+     * so the first page expands to three records. The loop must keep paging until a page returns
+     * fewer record groups than the batch size, otherwise the record on the second page (pid 3)
+     * is silently dropped.
+     */
+    #[Test]
+    public function collectScoresContinuesPagingWhenAPidHoldsMultipleRecords(): void
+    {
+        $subject = $this->createSubject(2);
+
+        $scores = $subject->collectScoresForTest(1, 0, ['seo' => 10]);
+
+        self::assertArrayHasKey('3-pages', $scores, 'Record on the second page was never scored.');
+        self::assertArrayHasKey('1-pages', $scores);
+        self::assertArrayHasKey('100-pages', $scores);
+        self::assertArrayHasKey('2-pages', $scores);
+    }
+
+    private function createSubject(int $batchSize): LinkingSuggestionsService
+    {
+        $siteService = $this->createMock(SiteService::class);
+        $pageRepository = $this->createMock(PageRepository::class);
+
+        return new class ($this->connectionPool, $pageRepository, $siteService, $batchSize) extends LinkingSuggestionsService {
+            /**
+             * @param array<string, int|string> $words
+             * @return array<string, float|int>
+             */
+            public function collectScoresForTest(int $site, int $languageId, array $words): array
+            {
+                $this->site = $site;
+                $this->languageId = $languageId;
+                $this->documentFrequencyCache = [];
+
+                return $this->collectScores($words);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* `findRecordsByStems()` paged with `LIMIT`/`OFFSET` over a `GROUP BY pid, tablenames` query that had no `ORDER BY`, so SQL row order was undefined
  * Consecutive pages could skip or duplicate record groups. Added `ORDER BY pid, tablenames` for a stable total ordering on the grouped columns.
* The loop continued while `$batchScoresSize === $batchSize`, but `$batchScoresSize` counted records grouped by `uid_foreign` while `$batchSize` counted `(pid, tablenames)` groups. Because one pid expands into many records, the counts diverged as soon as a pid held more than one analyzed record (normal for record folders), stopping after the first page and dropping all later results. The loop now terminates on the paged unit: `count($recordGroups) === $batchSize`.

## Relevant technical choices:

* Diverged from the setup from wordpress-seo because there it works with Indexable records and that does not have the structure of TYPO3

## Test instructions

This PR can be tested by following these steps:

* See new test
* Check if linking suggestions still work in existing setups

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [X] I have added unittests to verify the code works as intended