### PR TITLE
[BUGFIX] Prevent validated Yoast requests from populating the shared page cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 All notable changes to this project will be documented in this file.
 We will follow [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Validated Yoast frontend requests (snippet preview / analysis / crawler) no longer populate the shared frontend
+  page cache. These requests render with hidden pages/records visible (`PageRequestMiddleware` forces
+  `VisibilityAspect(true)`) and reuse the anonymous page-cache identifier, so persisting them poisoned the public
+  cache — e.g. hidden pages leaking into `HMENU`/directory menus rendered inside cached headers/footers, staying
+  visible to all visitors until the cache was flushed. A new `PageCacheWriteListener` on
+  `AfterCacheableContentIsGeneratedEvent` disables caching for these requests, mirroring the existing read-side
+  `PageCacheListener`
+
+### Deprecated
+
+- The `yoastSeoDisableAllCachesOnPreviewRequest` feature toggle. It only set the legacy `noCache` request attribute,
+  which is no longer honoured since TYPO3 v13, so it never disabled anything on v13+. Page-cache protection for
+  validated Yoast requests is now the unconditional default
+
 ## [12.1.2] July 8, 2026
 
 ### Fixed

--- a/Classes/EventListener/PageCacheWriteListener.php
+++ b/Classes/EventListener/PageCacheWriteListener.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the "yoast_seo" extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace YoastSeoForTypo3\YoastSeo\EventListener;
+
+use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
+use YoastSeoForTypo3\YoastSeo\Service\YoastRequestService;
+
+class PageCacheWriteListener
+{
+    public function __construct(
+        protected YoastRequestService $yoastRequestService
+    ) {}
+
+    public function __invoke(AfterCacheableContentIsGeneratedEvent $event): void
+    {
+        if ($this->yoastRequestService->isValidRequest($event->getRequest()->getServerParams())) {
+            // A validated Yoast request renders with hidden pages/records visible
+            // (PageRequestMiddleware forces VisibilityAspect(true)) and reuses the
+            // anonymous page-cache identifier. Persisting it would poison the shared
+            // page cache, so never write the analysis render to the page cache.
+            $event->disableCaching();
+        }
+    }
+}

--- a/Classes/Middleware/PageRequestMiddleware.php
+++ b/Classes/Middleware/PageRequestMiddleware.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\VisibilityAspect;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -25,7 +24,6 @@ final readonly class PageRequestMiddleware implements MiddlewareInterface
 {
     public function __construct(
         protected YoastRequestService $yoastRequestService,
-        protected Features $features,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -37,10 +35,9 @@ final readonly class PageRequestMiddleware implements MiddlewareInterface
         $context = GeneralUtility::makeInstance(Context::class);
         $context->setAspect('visibility', new VisibilityAspect(true));
 
-        if ($this->features->isFeatureEnabled('yoastSeoDisableAllCachesOnPreviewRequest')) {
-            $request = $request->withAttribute('noCache', true);
-        }
-
+        // Reading from the page cache is prevented by PageCacheListener and writing by
+        // PageCacheWriteListener, so the analysis always reflects the current content and
+        // never persists a "show hidden" render into the shared page cache.
         return $handler->handle($request);
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -94,6 +94,11 @@ services:
       - name: event.listener
         identifier: 'yoast-seo/page-cache-listener'
 
+  YoastSeoForTypo3\YoastSeo\EventListener\PageCacheWriteListener:
+    tags:
+      - name: event.listener
+        identifier: 'yoast-seo/page-cache-write-listener'
+
   YoastSeoForTypo3\YoastSeo\EventListener\FrontendRequestListener:
     tags:
       - name: event.listener


### PR DESCRIPTION
## Summary

A validated Yoast frontend request (snippet preview / content analysis / crawler) is rendered with hidden pages and records made visible, but it is still written into the **shared** frontend page cache under the **same** cache identifier as anonymous visitors. As a result, any hidden record that appears in a rendered menu/list (e.g. an `HMENU` `special = directory` in a globally cached header or footer) leaks into the public page cache and is served to everyone until the cache is flushed.

Because `PageCacheListener` already disables cache **reading** for these requests but nothing disables cache **writing**, the freshly rendered "show hidden" output is persisted and poisons the cache. This reproduces on TYPO3 v13 and v14.

## Steps to reproduce

1. A page template renders a directory menu (`HMENU` / `MenuProcessor`, `special = directory`) of a folder that contains **hidden** subpages, inside a globally cached element (e.g. a footer "jobs" list). Anonymous output correctly shows the empty/`else` state.
2. Flush the frontend cache.
3. Open the SEO analysis for that page in the backend (or send a `GET` to the page URL with a valid `X-Yoast-Page-Request` header).
4. Request the same URL as an anonymous visitor.

**Expected:** the anonymous output still shows the empty state; the analysis request must not populate the shared page cache.
**Actual:** the anonymous response now lists the hidden subpages, served from the cache entry written by the Yoast request. It persists until the next cache flush and recurs whenever the analysis is run again.

## Root cause

- `Middleware/PageRequestMiddleware` correctly forces `new VisibilityAspect(true)` for the analysis, and — behind `yoastSeoDisableAllCachesOnPreviewRequest` — only sets `$request->withAttribute('noCache', true)`.
- The `noCache` request attribute is **no longer honoured since TYPO3 v13**; cache disabling now goes through `frontend.cache.instruction` / `AfterCacheableContentIsGeneratedEvent`. So on v13+ the toggle is a no-op and never disabled anything.
- `EventListener/PageCacheListener` disables cache **reading** (`ShouldUseCachedPageDataIfAvailableEvent`), but there is **no write-side counterpart**. The `AfterCacheableContentIsGeneratedListener` that used to cover this was removed in 12.0.0.
- `PageCacheIdentifierListener` does not vary the identifier for Yoast requests, so the render is stored under the anonymous identifier → poisoning.

## Fix

- Add `EventListener/PageCacheWriteListener` on `AfterCacheableContentIsGeneratedEvent` that calls `$event->disableCaching()` for validated Yoast requests — the write-side counterpart to `PageCacheListener`. It is unconditional and self-contained (detected via `YoastRequestService::isValidRequest(...)`), matching how the read-side already behaves.
- Register it in `Configuration/Services.yaml` following the existing listener pattern.
- Remove the dead `noCache` request attribute from `PageRequestMiddleware` (no-op since v13) and the now unused `Features` dependency.
- Deprecate the `yoastSeoDisableAllCachesOnPreviewRequest` feature toggle in the CHANGELOG, since page-cache protection for Yoast requests is now the unconditional default.

## Backward compatibility

- The `yoastSeoDisableAllCachesOnPreviewRequest` toggle is only marked deprecated (not removed). It never had any effect on TYPO3 v13+.
- No public API changes other than dropping an unused constructor argument on the internal, DI-instantiated `PageRequestMiddleware`.

## Testing

Reproduced end-to-end against yoast_seo 12.1.2 / TYPO3 14.3.4 with a directory-menu footer over a folder of hidden pages:

- **Before:** anonymous footer empty → one validated Yoast request → anonymous footer now lists the hidden pages (poisoned).
- **After:** anonymous footer empty → validated Yoast request still shows the hidden pages in *its own* response (analysis stays correct) → anonymous footer stays empty. Normal anonymous page caching is unaffected.
